### PR TITLE
`freeze` and `evaluating` only make weakrefs to their items

### DIFF
--- a/src/rai_toolbox/_utils/stateful.py
+++ b/src/rai_toolbox/_utils/stateful.py
@@ -84,8 +84,8 @@ def freeze(
         for param in flatten_params(item):
             seen[param.requires_grad].add(param)
 
-        for param in seen[True]:
-            param.requires_grad_(False)
+    for param in seen[True]:
+        param.requires_grad_(False)
 
     def restore_state():
         for item in (True, False):

--- a/tests/test_utils/test_stateful.py
+++ b/tests/test_utils/test_stateful.py
@@ -116,7 +116,7 @@ def test_freeze_handles_multiple_references_to_same_tensor(
     x: tr.Tensor, num_repeats: int
 ):
     original_requires_grad = x.requires_grad
-    unfreeze = freeze([x] * (num_repeats + 1))
+    unfreeze = freeze(*[x] * (num_repeats + 1))
     assert x.requires_grad is False
     unfreeze()
     assert x.requires_grad is original_requires_grad


### PR DESCRIPTION
Closes #28 

Models and tensors will not be held in-memory if these decorators/contexts are the only references held.