### PR TITLE
Fix L1qNormedGradient

### DIFF
--- a/src/rai_toolbox/optim/lp_space.py
+++ b/src/rai_toolbox/optim/lp_space.py
@@ -699,8 +699,8 @@ class L1qNormedGradientOptim(ChainedParamTransformingOptimizer):
         tensor([1.0000, 0.1000, 0.1000], requires_grad=True)
         """
         super().__init__(
-            SignedGradientOptim,
             partial(TopQGradientOptimizer, q=q, dq=dq, generator=generator),
+            SignedGradientOptim,
             partial(L1NormedGradientOptim, div_by_zero_eps=div_by_zero_eps),
             params=params,
             InnerOpt=InnerOpt,

--- a/tests/test_optim/test_grad_transformation.py
+++ b/tests/test_optim/test_grad_transformation.py
@@ -671,3 +671,14 @@ def test_grad_scale_and_bias(
 
     if b1 != b3 or s1 != s3:
         assert tr.any(x1 != x3), (x1, x3)
+
+
+def test_l1q_regression():
+
+    g = tr.tensor([-1.0, -2.0, 3.0, 0.5])
+    p = tr.ones_like(g, requires_grad=True)
+
+    opt = L1qNormedGradientOptim([p], q=0.5, param_ndim=1, lr=1)
+    p.backward(g)
+    opt.step()
+    assert_allclose(actual=p.grad, expected=tr.tensor([0.0, -0.5, 0.5, 0.0]))


### PR DESCRIPTION
I think #37 introduced a bug in which `L1qNormedGradient` applied:

```
sign(grad) -> top-Q(grad) -> L1-Norm(grad)
```

where it *should* be:

```
top-Q(grad) -> sign(grad) -> L1-Norm(grad)
``` 

This adds a test to catch this, and adds a fix