### PR TITLE
Make sure `overrides` input list for `Workflow.run` is not modified

### DIFF
--- a/src/rai_toolbox/mushin/workflows.py
+++ b/src/rai_toolbox/mushin/workflows.py
@@ -182,17 +182,19 @@ class BaseWorkflow(ABC):
         """
         self._workflow_overrides = workflow_overrides
 
-        if overrides is None:
-            overrides = []
+        launch_overrides = []
+
+        if overrides is not None:
+            launch_overrides.extend(overrides)
 
         if working_dir is not None:
-            overrides.append(f"hydra.sweep.dir={working_dir}")
+            launch_overrides.append(f"hydra.sweep.dir={working_dir}")
 
         if sweeper is not None:
-            overrides.append(f"hydra/sweeper={sweeper}")
+            launch_overrides.append(f"hydra/sweeper={sweeper}")
 
         if launcher is not None:
-            overrides.append(f"hydra/launcher={launcher}")
+            launch_overrides.append(f"hydra/launcher={launcher}")
 
         for k, v in workflow_overrides.items():
             value_check(k, v, type_=(int, float, bool, str, dict, multirun, hydra_list))
@@ -206,13 +208,13 @@ class BaseWorkflow(ABC):
             ):
                 prefix = "+"
 
-            overrides.append(f"{prefix}{k}={v}")
+            launch_overrides.append(f"{prefix}{k}={v}")
 
         # Run a Multirun over epsilons
         (jobs,) = launch(
             self.eval_task_cfg,
             zen(self.evaluation_task),
-            overrides=overrides,
+            overrides=launch_overrides,
             multirun=True,
         )
 

--- a/tests/test_mushin/test_workflows.py
+++ b/tests/test_mushin/test_workflows.py
@@ -122,8 +122,13 @@ def test_robustnesscurve_hydra(sweeper, launcher):
 def test_robustnesscurve_override():
     LocalRobustness = create_workflow()
     task = LocalRobustness(make_config(epsilon=0))
-    task.run(epsilon=[0, 1, 2, 3], overrides=["hydra.sweep.dir=test_sweep_dir"])
+
+    overrides = ["hydra.sweep.dir=test_sweep_dir"]
+    task.run(epsilon=[0, 1, 2, 3], overrides=overrides)
     assert Path("test_sweep_dir").exists()
+
+    # make sure overrides is not modified
+    assert len(overrides) == 1
 
 
 @pytest.mark.usefixtures("cleandir")


### PR DESCRIPTION
Fixes behavior, input list is no longer modified. 

https://github.com/mit-ll-responsible-ai/responsible-ai-toolbox/blob/c3d9057b137784b806c0cd440bf7aaf859dc7edf/src/rai_toolbox/mushin/workflows.py#L185
