### PR TITLE
`zen` should not attempt to populate `*args` and `**kwargs` 

### DIFF
--- a/tests/test_mushin/test_workflows.py
+++ b/tests/test_mushin/test_workflows.py
@@ -12,6 +12,7 @@ import pytest
 import torch as tr
 import xarray as xr
 from hydra_zen import make_config
+from hydra_zen.errors import HydraZenValidationError
 from hypothesis import given, settings
 from hypothesis.extra.numpy import array_shapes, arrays
 from xarray.testing import assert_identical
@@ -74,7 +75,7 @@ def test_robustnesscurve_validate():
     task.validate()
 
     task = LocalRobustness()
-    with pytest.raises(TypeError):
+    with pytest.raises(HydraZenValidationError):
         task.validate()
 
 

--- a/tests/test_mushin/test_zen.py
+++ b/tests/test_mushin/test_zen.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 import pytest
 from hydra_zen import builds, make_config
+from hydra_zen.errors import HydraZenValidationError
 from hypothesis import given
 from hypothesis import strategies as st
 
@@ -10,6 +11,18 @@ from rai_toolbox.mushin.hydra import zen
 
 
 def function(x: int, y: int, z: int = 2):
+    return x * y * z
+
+
+def function_with_args(x: int, y: int, z: int = 2, *args):
+    return x * y * z
+
+
+def function_with_kwargs(x: int, y: int, z: int = 2, **kwargs):
+    return x * y * z
+
+
+def function_with_args_kwargs(x: int, y: int, z: int = 2, *args, **kwargs):
     return x * y * z
 
 
@@ -21,7 +34,16 @@ class A:
 method = A().f
 
 
-@pytest.mark.parametrize("func", [function, method])
+@pytest.mark.parametrize(
+    "func",
+    [
+        function,
+        function_with_args,
+        function_with_kwargs,
+        function_with_args_kwargs,
+        method,
+    ],
+)
 @pytest.mark.parametrize(
     "cfg",
     [
@@ -32,11 +54,20 @@ method = A().f
     ],
 )
 def test_zen_validation(cfg, func):
-    with pytest.raises(TypeError):
+    with pytest.raises(HydraZenValidationError):
         zen(func).validate(cfg)
 
 
-@pytest.mark.parametrize("func", [function, method])
+@pytest.mark.parametrize(
+    "func",
+    [
+        function,
+        function_with_args,
+        function_with_kwargs,
+        function_with_args_kwargs,
+        method,
+    ],
+)
 @given(
     x=st.integers(-10, 10),
     y=st.integers(-10, 10),


### PR DESCRIPTION
Previously `zen` would attempt to find a `kwargs` field in the config:

Before:

```python
def f(x, **kwargs): return x

cfg = make_config(x=1)

zen(f)(cfg)  # AttributeError: 'Config' object has no attribute 'kwargs'
```

Now `zen` skips `*args`, `**kwargs`. 

```python
def f(x, **kwargs): return x

cfg = make_config(x=1)

zen(f)(cfg)  # returns 1
```

In the future we might permit some configured behavior for populating these.




