### PR TITLE
Add working_subdir data variable to xarray

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ TESTS_REQUIRE = [
     "hypothesis >= 6.41.0",
     "mygrad >= 2.0.0",
     "omegaconf >= 2.1.1",
+    "netCDF4 >= 1.5.8",
 ]
 
 DESCRIPTION = "PyTorch-centric library for evaluating and enhancing the robustness of AI technologies"

--- a/src/rai_toolbox/mushin/workflows.py
+++ b/src/rai_toolbox/mushin/workflows.py
@@ -872,6 +872,16 @@ class RobustnessCurve(MultiRunMetricsWorkflow):
 
         Parameters
         ----------
+        include_working_subdirs_as_data_var : bool, optional (default=False)
+            If `True` then the data-variable "working_subdir" will be included in the
+            xarray. This data variable is used to lookup the working sub-dir path
+            (a string) by multirun coordinate.
+
+        coord_from_metrics : str | None (default: None)
+            If not `None` defines the metric key to use as a coordinate
+            in the `Dataset`.  This function assumes that this coordinate
+            represents the leading dimension for all data-variables.
+
         non_multirun_params_as_singleton_dims : bool, optional (default=False)
             If `True` then non-multirun entries from `workflow_overrides` will be
             included as length-1 dimensions in the xarray. Useful for merging/

--- a/src/rai_toolbox/mushin/workflows.py
+++ b/src/rai_toolbox/mushin/workflows.py
@@ -676,6 +676,7 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
 
     def to_xarray(
         self,
+        include_working_subdirs_as_data_var: bool = False,
         coord_from_metrics: Optional[str] = None,
         non_multirun_params_as_singleton_dims: bool = False,
     ):
@@ -683,7 +684,12 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
 
         Parameters
         ----------
-        coord_from_metrics: str | None (default: None)
+        include_working_subdirs_as_data_var : bool, optional (default=False)
+            If `True` then the data-variable "working_subdir" will be included in the
+            xarray. This data variable is used to lookup the working sub-dir path
+            (a string) by multirun coordinate.
+
+        coord_from_metrics : str | None (default: None)
             If not `None` defines the metric key to use as a coordinate
             in the `Dataset`.  This function assumes that this coordinate
             represents the leading dimension for all data-variables.
@@ -731,8 +737,17 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
         coords: Dict[str, Any] = orig_coords.copy()
         shape = tuple(len(v) for v in coords.values())
 
+        metrics_to_add = self.metrics.copy()
+        if (
+            include_working_subdirs_as_data_var
+            and self.multirun_working_dirs is not None
+        ):
+            metrics_to_add["working_subdir"] = [
+                str(p) for p in self.multirun_working_dirs
+            ]
+
         data = {}
-        for k, v in self.metrics.items():
+        for k, v in metrics_to_add.items():
             if coord_from_metrics and k == coord_from_metrics:
                 continue
 
@@ -849,6 +864,7 @@ class RobustnessCurve(MultiRunMetricsWorkflow):
 
     def to_xarray(
         self,
+        include_working_subdirs_as_data_var: bool = False,
         coord_from_metrics: Optional[str] = None,
         non_multirun_params_as_singleton_dims: bool = False,
     ):
@@ -870,6 +886,7 @@ class RobustnessCurve(MultiRunMetricsWorkflow):
         return (
             super()
             .to_xarray(
+                include_working_subdirs_as_data_var=include_working_subdirs_as_data_var,
                 coord_from_metrics=coord_from_metrics,
                 non_multirun_params_as_singleton_dims=non_multirun_params_as_singleton_dims,
             )


### PR DESCRIPTION
Adds `include_working_subdirs_as_data_var` to `MultiRunMetricsWorkflow.to_xarray`.

Example:

```python
from rai_toolbox.mushin import MultiRunMetricsWorkflow, multirun


class NoMetrics(MultiRunMetricsWorkflow):
    @staticmethod
    def evaluation_task(x: int, y: int):
        return dict(xx=x, yy=y)
```

```python
wf = NoMetrics()
>>> wf.run(x=multirun([-1, 0, 1]), y=multirun([-10, 10]))
[2022-05-17 12:01:33,337][HYDRA] Launching 6 jobs locally
[2022-05-17 12:01:33,337][HYDRA] 	#0 : +x=-1 +y=-10
[2022-05-17 12:01:33,394][HYDRA] 	#1 : +x=-1 +y=10
[2022-05-17 12:01:33,488][HYDRA] 	#2 : +x=0 +y=-10
[2022-05-17 12:01:33,546][HYDRA] 	#3 : +x=0 +y=10
[2022-05-17 12:01:33,604][HYDRA] 	#4 : +x=1 +y=-10
[2022-05-17 12:01:33,661][HYDRA] 	#5 : +x=1 +y=10
```

```python
>>> xdata = wf.to_xarray(include_working_subdirs_as_data_var=True)
>>> xdata.working_subdir
<xarray.DataArray 'working_subdir' (x: 3, y: 2)>
array([['/home/public-responsible-ai-toolbox/scratch/multirun/2022-05-17/12-01-33/0',
        '/home/public-responsible-ai-toolbox/scratch/multirun/2022-05-17/12-01-33/1'],
       ['/home/public-responsible-ai-toolbox/scratch/multirun/2022-05-17/12-01-33/2',
        '/home/public-responsible-ai-toolbox/scratch/multirun/2022-05-17/12-01-33/3'],
       ['/home/public-responsible-ai-toolbox/scratch/multirun/2022-05-17/12-01-33/4',
        '/home/public-responsible-ai-toolbox/scratch/multirun/2022-05-17/12-01-33/5']],
      dtype='<U82')
Coordinates:
  * x        (x) int64 -1 0 1
  * y        (y) int64 -10 10
```

Looking up subdir by coordinate:

```python
>>> xdata.working_subdir.sel(x=0, y=-10).item()
'/home/public-responsible-ai-toolbox/scratch/multirun/2022-05-17/12-01-33/2'
```