### PR TITLE
Improve parity between pre-step and post-step method names

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -8,6 +8,18 @@ Changelog
 This is a record of all past rAI-toolbox releases and what went into them, in reverse 
 chronological order. All previous releases should still be available on pip.
 
+.. _v0.2.0:
+
+------------------
+0.2.0 - 2022-XX-XX
+------------------
+
+.. note:: This is documentation for an unreleased version of the toolbox
+
+
+- Added the method `ParamTransformingOptimizer._post_step_transform_` to fulfill the role of `ParamTransformingOptimizer.project`, for the sake of having parity among the names of the pre-step and post-step methods. See :pull:`54` for details.
+
+
 .. _v0.1.1:
 
 ------------------

--- a/docs/source/generated/rai_toolbox.optim.ParamTransformingOptimizer.rst
+++ b/docs/source/generated/rai_toolbox.optim.ParamTransformingOptimizer.rst
@@ -9,7 +9,8 @@ rai\_toolbox.optim.ParamTransformingOptimizer
    .. automethod:: __init__
    .. automethod:: _pre_step_transform_
    .. automethod:: _post_step_transform_
-   .. automethod:: project
+   .. automethod:: _apply_pre_step_transform_
+   .. automethod:: _apply_post_step_transform_
    
    .. rubric:: Methods
 
@@ -18,4 +19,5 @@ rai\_toolbox.optim.ParamTransformingOptimizer
       ~ParamTransformingOptimizer.__init__
       ~ParamTransformingOptimizer._pre_step_transform_
       ~ParamTransformingOptimizer._post_step_transform_
-      ~ParamTransformingOptimizer.project
+      ~ParamTransformingOptimizer._apply_pre_step_transform_
+      ~ParamTransformingOptimizer._apply_post_step_transform_

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ CLASSIFIERS = [
 KEYWORDS = "machine learning robustness pytorch responsible AI"
 INSTALL_REQUIRES = [
     "torchvision >= 0.10.0",
-    "torch >= 1.9.0",
+    # pytorch 1.9.1 has bug for its view inplace-update checks
+    "torch >= 1.9.0, != 1.9.1",
     "torchmetrics >= 0.6.0",
     "typing-extensions >= 4.1.1",
 ]

--- a/src/rai_toolbox/optim/optimizer.py
+++ b/src/rai_toolbox/optim/optimizer.py
@@ -510,11 +510,11 @@ class ParamTransformingOptimizer(Optimizer, metaclass=ABCMeta):
         return None
 
     @torch.no_grad()
-    def project(self) -> None:
+    def _apply_post_step_transform_(self) -> None:
         """Update each parameter in-place by calling `_post_step_transform_` on the
         parameter.
 
-        `.project` is called automatically by `.step`."""
+        This is called automatically by `.step`."""
         for group in self.param_groups:
             param_ndim = group["param_ndim"]
 
@@ -522,7 +522,14 @@ class ParamTransformingOptimizer(Optimizer, metaclass=ABCMeta):
                 p = _to_batch(p, param_ndim)
                 self._post_step_transform_(param=p, optim_group=group)
 
+    project = _apply_post_step_transform_  # TODO: deprecate this
+
+    @torch.no_grad()
     def _apply_pre_step_transform_(self):
+        """Update each parameter in-place by calling `_pre_step_transform_` on the
+        parameter.
+
+        This is called automatically by `.step`."""
         for group in self.param_groups:
             for p in group["params"]:
                 p: Tensor
@@ -584,7 +591,7 @@ class ParamTransformingOptimizer(Optimizer, metaclass=ABCMeta):
             self._apply_pre_step_transform_()
             self.inner_opt.step()
             loss = None
-        self.project()
+        self._apply_post_step_transform_()
         loss = cast(Optional[Union[float, Tensor]], loss)
         return loss
 

--- a/src/rai_toolbox/optim/optimizer.py
+++ b/src/rai_toolbox/optim/optimizer.py
@@ -514,7 +514,7 @@ class ParamTransformingOptimizer(Optimizer, metaclass=ABCMeta):
         """Update each parameter in-place by calling `_post_step_transform_` on the
         parameter.
 
-        This is called automatically by `.step`."""
+        This is called automatically by `.step` after `InnerOpt.step()` has been called."""
         for group in self.param_groups:
             param_ndim = group["param_ndim"]
 
@@ -529,7 +529,8 @@ class ParamTransformingOptimizer(Optimizer, metaclass=ABCMeta):
         """Update each parameter in-place by calling `_pre_step_transform_` on the
         parameter.
 
-        This is called automatically by `.step`."""
+        This is called automatically by `.step` before `InnerOpt.step()` has been
+        called."""
         for group in self.param_groups:
             for p in group["params"]:
                 p: Tensor

--- a/src/rai_toolbox/optim/optimizer.py
+++ b/src/rai_toolbox/optim/optimizer.py
@@ -649,7 +649,7 @@ class ChainedParamTransformingOptimizer(ParamTransformingOptimizer):
         param_ndim : int | None, optional (default=-1)
             Determines how a parameter and its gradient is temporarily reshaped prior
             to being passed to both `_pre_step_transform_` and `_post_step_transform_`.
-            By default,the transformation broadcasts over the tensor's first dimension
+            By default, the transformation broadcasts over the tensor's first dimension
             in a batch-like style.
 
             - A positive number determines the dimensionality of the tensor that the transformation will act on.


### PR DESCRIPTION
`ParamTransformingOptimizer.project` was the post-step equivalent to `ParamTransformingOptimizer._apply_pre_step_transform_`. This PR thus renames `project` as `_apply_post_step_transform_`. The `project` method is still provided (as a mirror of `_apply_post_step_transform_`) for the sake of backwards compatibility, but I think that we may want to deprecate it.

This PR also ensures that `_pre_step_transform_` and  `_post_step_transform_` occur in the no-grad context so that they can be called on their own reliably.

Lastly, it looks like there was a bug in specifically in pytorch 1.9.1 that would incorrectly see in-place modifications of tensors as invalid ( https://github.com/pytorch/pytorch/pull/59817). Thus we exclude pytorch 1.9.1 from our dependencies.