### PR TITLE
Deprecate `ParamTransformingOptimizer.project`

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -17,7 +17,9 @@ chronological order. All previous releases should still be available on pip.
 .. note:: This is documentation for an unreleased version of the toolbox
 
 
-- Added the method `ParamTransformingOptimizer._post_step_transform_` to fulfill the role of `ParamTransformingOptimizer.project`, for the sake of having parity among the names of the pre-step and post-step methods. See :pull:`54` for details.
+Deprecations
+------------
+`~ParamTransformingOptimizer.project` is now deprecated in favor of `~ParamTransformingOptimizer._post_step_transform_`. It will be removed in rAI-toolbox v0.3.0. See :pull:`54` for details.
 
 
 .. _v0.1.1:

--- a/experiments/setup.py
+++ b/experiments/setup.py
@@ -6,8 +6,9 @@ from setuptools import find_packages, setup
 
 INSTALL_REQUIRES = [
     "matplotlib >= 2.0.0",
-    "hydra_zen >= 0.5.0",
+    "hydra_zen >= 0.7.0",
     "pytorch-lightning >= 1.5.0",
+    "protobuf <= 3.20.1",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
             "hydra-zen >= 0.7.0",
             "xarray >= 0.19.0",
             "matplotlib >= 3.3",
-            "protobuf <= 3.20.1",  # strict TODO: Remove after tensorboard gets compatible https://github.com/tensorflow/tensorboard/issues/5708
+            "protobuf < 3.20",  # strict TODO: Remove after tensorboard gets compatible https://github.com/tensorflow/tensorboard/issues/5708
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
             "hydra-zen >= 0.7.0",
             "xarray >= 0.19.0",
             "matplotlib >= 3.3",
+            "protobuf <= 3.20.1",  # strict TODO: Remove after tensorboard gets compatible https://github.com/tensorflow/tensorboard/issues/5708
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
             "hydra-zen >= 0.7.0",
             "xarray >= 0.19.0",
             "matplotlib >= 3.3",
-            "protobuf < 3.20",  # strict TODO: Remove after tensorboard gets compatible https://github.com/tensorflow/tensorboard/issues/5708
+            "protobuf <= 3.20.1",  # strict TODO: Remove after tensorboard gets compatible https://github.com/tensorflow/tensorboard/issues/5708
         ],
     },
 )

--- a/src/rai_toolbox/mushin/hydra.py
+++ b/src/rai_toolbox/mushin/hydra.py
@@ -18,14 +18,15 @@ from typing import (
 
 from hydra_zen import instantiate
 from hydra_zen.errors import HydraZenValidationError
-from omegaconf import OmegaConf
-from typing_extensions import Literal, ParamSpec
+from hydra_zen.typing._implementations import DataClass
+from omegaconf import DictConfig, ListConfig, OmegaConf
+from typing_extensions import Literal, ParamSpec, TypeGuard
 
 T1 = TypeVar("T1")
 P = ParamSpec("P")
 
 
-def is_config(cfg: Any) -> bool:
+def is_config(cfg: Any) -> TypeGuard[Union[DataClass, DictConfig, ListConfig]]:
     return is_dataclass(cfg) or OmegaConf.is_config(cfg)
 
 

--- a/src/rai_toolbox/mushin/workflows.py
+++ b/src/rai_toolbox/mushin/workflows.py
@@ -1048,7 +1048,7 @@ class RobustnessCurve(MultiRunMetricsWorkflow):
         save_filename: Optional[str] = None,
         non_multirun_params_as_singleton_dims: bool = False,
         **kwargs,
-    ) -> None:
+    ) -> Any:
         """Plot metrics versus `epsilon`.
 
         Using the `xarray.Dataset` from `to_xarray`, plot the metrics

--- a/src/rai_toolbox/optim/optimizer.py
+++ b/src/rai_toolbox/optim/optimizer.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import inspect
+import warnings
 from abc import ABCMeta
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast, overload
 
@@ -514,7 +515,8 @@ class ParamTransformingOptimizer(Optimizer, metaclass=ABCMeta):
         """Update each parameter in-place by calling `_post_step_transform_` on the
         parameter.
 
-        This is called automatically by `.step` after `InnerOpt.step()` has been called."""
+        This is called automatically by `.step()` after `InnerOpt.step()` has been
+        called."""
         for group in self.param_groups:
             param_ndim = group["param_ndim"]
 
@@ -522,14 +524,32 @@ class ParamTransformingOptimizer(Optimizer, metaclass=ABCMeta):
                 p = _to_batch(p, param_ndim)
                 self._post_step_transform_(param=p, optim_group=group)
 
-    project = _apply_post_step_transform_  # TODO: deprecate this
+    def project(self):
+        """
+        .. deprecated:: 0.2.0
+          `project` will be removed in rai-toolbox 0.3.0, it is replaced by
+          `_apply_post_step_transform_`
+
+        Update each parameter in-place by calling `_post_step_transform_` on the
+        parameter.
+
+        This is called automatically by `.step()` after `InnerOpt.step()` has been
+        called."""
+        warnings.warn(
+            FutureWarning(
+                "`project` will be removed in rai-toolbox 0.3.0, it is replaced by "
+                "`_apply_post_step_transform_`"
+            ),
+            stacklevel=2,
+        )
+        return self._apply_post_step_transform_()
 
     @torch.no_grad()
     def _apply_pre_step_transform_(self):
         """Update each parameter in-place by calling `_pre_step_transform_` on the
         parameter.
 
-        This is called automatically by `.step` before `InnerOpt.step()` has been
+        This is called automatically by `.step()` before `InnerOpt.step()` has been
         called."""
         for group in self.param_groups:
             for p in group["params"]:

--- a/tests/test_mushin/test_lightning_hydra_ddp.py
+++ b/tests/test_mushin/test_lightning_hydra_ddp.py
@@ -121,6 +121,7 @@ def test_ddp_with_hydra_output_subdir(subdir):
     if subdir is None:
         subdir = ".hydra"
 
+    assert isinstance(job.working_dir, str)
     cfg_file = Path(job.working_dir) / subdir / "config.yaml"
     assert cfg_file.exists()
 
@@ -139,6 +140,7 @@ def test_ddp_with_hydra_subprocess_runs_correct_mode(testing, predicting):
     Config = make_config(trainer=TrainerConfig, module=module, devices=2)
     job = launch(Config, task_fn, overrides=overrides)
 
+    assert isinstance(job.working_dir, str)
     cfg_file_run = Path(job.working_dir) / ".hydra/config.yaml"
     assert cfg_file_run.exists()
     cfg_run = load_from_yaml(cfg_file_run)
@@ -148,6 +150,7 @@ def test_ddp_with_hydra_subprocess_runs_correct_mode(testing, predicting):
     assert "run_predict" in cfg_run
     assert cfg_run.run_predict == predicting
 
+    assert isinstance(job.working_dir, str)
     cfg_file_subprocess = Path(job.working_dir) / ".pl_hydra_rank_1/config.yaml"
     assert cfg_file_subprocess.exists()
     cfg_subprocess = load_from_yaml(cfg_file_subprocess)

--- a/tests/test_optim/test_grad_transformation.py
+++ b/tests/test_optim/test_grad_transformation.py
@@ -208,7 +208,7 @@ def test_project_returns_fixed_point(
     # don't permit no-op
     assume(not tr.all(x1 == x_orig))
 
-    s.project()
+    s._apply_post_step_transform_()
     x2 = x.detach().clone()
 
     note(f"x1: {x1}")
@@ -692,3 +692,11 @@ def test_l1q_regression():
     p.backward(g)
     opt.step()
     assert_allclose(actual=p.grad, expected=tr.tensor([0.0, -0.5, 0.5, 0.0]))
+
+
+def test_project_is_deprecated():
+    x = tr.tensor(1.0, requires_grad=True)
+    optim = L2ProjectedOptim([x], lr=1.0, epsilon=2.0, param_ndim=None)
+
+    with pytest.warns(FutureWarning):
+        optim.project()

--- a/tests/test_perturbations/test_solvers.py
+++ b/tests/test_perturbations/test_solvers.py
@@ -400,6 +400,7 @@ class dummy_stateful_solver:
         return tr.tensor([[self.state - 1]]), tr.tensor([[self.state - 1]])
 
 
+@settings(deadline=None)
 @given(repeats=st.integers(1, 10), targeted=st.booleans())
 def test_random_restart_targeted(repeats, targeted: bool):
 


### PR DESCRIPTION
#54 added `ParamTransformingOptimizer._post_step_transform_` to be used instead of `ParamTransformingOptimizer.project`. This PR formally deprecates `project`

Also pins protobuf dependency: https://github.com/tensorflow/tensorboard/issues/5708