### PR TITLE
Add pre-release and nightly CI jobs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,62 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+
+jobs:
+  test-against-pre-releases-of-dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Cache tox environments
+      id: cache-min-deps
+      uses: actions/cache@v3
+      with:
+        path: .tox
+        key: tox-pre-deps-${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
+    - name: Test with tox
+      run: tox -e pre-release
+  run-pyright:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-node@v2-beta
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Get npm cache directory
+      id: npm-cache
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+    - uses: actions/cache@v3
+      with:
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - name: Install pyright
+      run: sudo npm install -g pyright@">1.1.246"
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade --upgrade-strategy eager -e .[mushin,tests]
+        pip install matplotlib
+    - name: Run pyright basic on src
+      run: pyright --lib tests/ src/rai_toolbox/mushin/

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -178,6 +178,28 @@ jobs:
     - name: Test with tox
       run: tox -e min-deps
 
+  test-against-pre-releases-of-dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Cache tox environments
+      id: cache-min-deps
+      uses: actions/cache@v3
+      with:
+        path: .tox
+        key: tox-pre-deps-${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
+    - name: Test with tox
+      run: tox -e pre-release
+
   run-pyright:
     runs-on: ubuntu-latest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,9 @@ commands = pytest --cov-report term-missing --cov-config=setup.cfg --cov-branch 
 
 [testenv:pre-release]  # test against pre-releases of dependencies
 pip_pre = true
-deps = {[testenv]deps}
+extras = 
+    tests
+    mushin
 basepython = python3.8
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,13 @@ deps = coverage
        pytest-cov
 commands = pytest --cov-report term-missing --cov-config=setup.cfg --cov-branch --cov=rai_toolbox --hypothesis-profile ci tests
 
+
+[testenv:pre-release]  # test against pre-releases of dependencies
+pip_pre = true
+deps = {[testenv]deps}
+basepython = python3.8
+
+
 # runs experiments that don't require additional dependencies
 [testenv:experiments-checks]
 basepython = python3.8


### PR DESCRIPTION
Nightly job runs our test suite against pre-release versions of dependencies and also runs our pyright tests