### PR TITLE
Ensure workflow overrides roundtrip

### DIFF
--- a/src/rai_toolbox/mushin/workflows.py
+++ b/src/rai_toolbox/mushin/workflows.py
@@ -389,7 +389,6 @@ class BaseWorkflow:
         if pre_task_fn_wrapper is None:
             pre_task_fn_wrapper = _identity
 
-        print(launch_overrides)
         # Run a Multirun over epsilons
         jobs = launch(
             self.eval_task_cfg,

--- a/src/rai_toolbox/mushin/workflows.py
+++ b/src/rai_toolbox/mushin/workflows.py
@@ -33,7 +33,7 @@ from rai_toolbox._utils import value_check
 
 from .hydra import zen
 
-LoadedValue: TypeAlias = Union[str, int, float]
+LoadedValue: TypeAlias = Union[str, int, float, bool, List[Any], Dict[str, Any]]
 
 __all__ = [
     "BaseWorkflow",
@@ -159,21 +159,19 @@ class BaseWorkflow:
         self._working_dir = path
 
     @staticmethod
-    def _parse_overrides(overrides: List[str]) -> Dict[str, Any]:
+    def _parse_overrides(
+        overrides,
+    ) -> Dict[str, Union[LoadedValue, Sequence[LoadedValue]]]:
         parser = OverridesParser.create()
         parsed_overrides = parser.parse_overrides(overrides=overrides)
 
         output = {}
+
         for override in parsed_overrides:
+            param_name = override.get_key_element()
+            val = override.value()
             if override.is_sweep_override():
-                param_name = override.get_key_element()
-                val = [
-                    _num_from_string(val) for val in override.sweep_string_iterator()
-                ]
-            else:
-                param_name = override.get_key_element()
-                val = override.get_value_element_as_str()
-                val = _num_from_string(val)
+                val = multirun(val.list)  # type: ignore
 
             param_name = param_name.split("+")[-1]
             output[param_name] = val
@@ -184,7 +182,31 @@ class BaseWorkflow:
     def multirun_task_overrides(
         self,
     ) -> Dict[str, Union[LoadedValue, Sequence[LoadedValue]]]:
-        # e.g. {'epsilon': [1.0, 2.0, 3.0], "foo": "apple"}
+        """Returns override param-name -> value.
+
+        A sequence of overrides associated with a multirun will
+        be stored in a `rai_toolbox.mushin.multirun` list. This
+        enables one to distinguish this from an override whose sole
+        value was a list of values.
+
+        Returns
+        -------
+        multirun_task_overrides: Dict[str, LoadedValue | Sequence[LoadedValue]]
+
+        Examples
+        --------
+        >>> from rai_toolbox.mushin import multirun, hydra_list
+        >>>
+        >>> class WorkFlow(MultiRunMetricsWorkflow):
+        ...     @staticmethod
+        ...     def evaluation_task(*args, **kwargs):
+        ...         return None
+        >>>
+        >>> wf = WorkFlow()
+        >>> wf.run(foo=hydra_list(["val"]), bar=multirun(["a", "b"]), apple=1)
+        >>> wf.multirun_task_overrides
+        {'foo': ['val'], 'bar': multirun(['a', 'b']), 'apple': 1}
+        """
         if not self._multirun_task_overrides:
 
             overrides = load_from_yaml(
@@ -192,7 +214,7 @@ class BaseWorkflow:
             ).hydra.overrides.task
 
             output = self._parse_overrides(overrides)
-            self._multirun_task_overrides.update(output)
+            self._multirun_task_overrides = output
 
         return self._multirun_task_overrides
 
@@ -367,6 +389,7 @@ class BaseWorkflow:
         if pre_task_fn_wrapper is None:
             pre_task_fn_wrapper = _identity
 
+        print(launch_overrides)
         # Run a Multirun over epsilons
         jobs = launch(
             self.eval_task_cfg,
@@ -404,17 +427,6 @@ class BaseWorkflow:
     def to_xarray(self):  # pragma: no cover
         """Convert workflow data to xArray Dataset or DataArray."""
         raise NotImplementedError()
-
-
-def _num_from_string(str_input: str) -> LoadedValue:
-    try:
-        val = float(str_input)
-        if val.is_integer() and "." not in str_input:
-            # v is e.g., 1 or -2. Not 1.0 or -2.0
-            val = int(str_input)
-        return val
-    except ValueError:
-        return str_input
 
 
 def _non_str_sequence(x: Any) -> TypeGuard[Sequence[Any]]:
@@ -828,9 +840,21 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
             else:
                 self.load_metrics(metrics_filename)
 
+        # all overrides containing non-multirun lists must be converted to
+        # strings so that xarray treats that list value as a "scalar"
+        cast_overrides = {}
+        for k, value in self.multirun_task_overrides.items():
+            if _non_str_sequence(value):
+                value = (
+                    [str(_v) if _non_str_sequence(_v) else _v for _v in value]
+                    if isinstance(value, multirun)
+                    else str(value)
+                )
+            cast_overrides[k] = value
+
         orig_coords = {
             k: (v if _non_str_sequence(v) else [v])
-            for k, v in self.multirun_task_overrides.items()
+            for k, v in cast_overrides.items()
             if non_multirun_params_as_singleton_dims or _non_str_sequence(v)
         }
 
@@ -850,13 +874,7 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
                 v = v[0]
             metric_coords[coord_from_metrics] = v
 
-        # non-multirun overrides
-        # TODO: cast "True"/"False" to bool
-        attrs = {
-            k: v
-            for k, v in self.multirun_task_overrides.items()
-            if not _non_str_sequence(v)
-        }
+        attrs = {k: v for k, v in cast_overrides.items() if not _non_str_sequence(v)}
 
         # we will add additional coordinates as-needed for multi-dim metrics
         coords: Dict[str, Any] = orig_coords.copy()

--- a/tests/test_mushin/test_workflows.py
+++ b/tests/test_mushin/test_workflows.py
@@ -308,7 +308,7 @@ def test_robustness_with_multidim_metrics_with_iteration(as_tensor: bool):
     ]
     assert xarray.accuracies.shape == (3, 2, 10)
     assert xarray.images.shape == (3, 2, 10, 4, 4)
-    assert xarray.attrs == {"foo": "val", "as_tensor": str(as_tensor)}
+    assert xarray.attrs == {"foo": "val", "as_tensor": as_tensor}
 
     for eps, expected in zip([1.0, 2.0, 3.0], [99.0, 96.0, 91.0]):
         # test that results were organized as-expected

--- a/tests/test_mushin/test_workflows.py
+++ b/tests/test_mushin/test_workflows.py
@@ -1,7 +1,7 @@
 # Copyright 2022, MASSACHUSETTS INSTITUTE OF TECHNOLOGY
 # Subject to FAR 52.227-11 – Patent Rights – Ownership by the Contractor (May 2014).
 # SPDX-License-Identifier: MIT
-
+import string
 from pathlib import Path
 from typing import Optional, Sequence
 
@@ -558,3 +558,56 @@ def test_raises_on_non_static_method():
 
     with pytest.raises(TypeError, match="pre_task must be a static method"):
         NonStaticPreTask().run()
+
+
+@pytest.mark.usefixtures("cleandir")
+@settings(max_examples=10, deadline=None)
+@given(
+    int_=st.integers(),
+    bool_=st.booleans(),
+    float_=st.floats(-10, 10),
+    list_=st.lists(st.integers()),
+    str_=st.text(alphabet=string.ascii_lowercase).filter(
+        lambda x: x != "true" and x != "false"
+    ),
+    mrun=st.lists(
+        st.booleans() | st.lists(st.integers()),
+        min_size=2,
+        max_size=5,
+    ).map(multirun),
+)
+def test_overrides_roundtrip(
+    int_,
+    bool_,
+    float_,
+    str_,
+    list_,
+    mrun,
+):
+    class WorkFlow(MultiDimIterationMetrics):
+        @staticmethod
+        def evaluation_task():
+            pass
+
+    wf = WorkFlow()
+    overrides = dict(
+        int_=int_,
+        float_=float_,
+        str_=str_,
+        bool_=bool_,
+        list_=hydra_list(list_),
+        mrun=mrun,
+    )
+    wf.run(**overrides)
+
+    assert wf.multirun_task_overrides == overrides
+    xdata = wf.to_xarray(non_multirun_params_as_singleton_dims=True)
+    assert xdata.int_.item() == int_
+    assert xdata.bool_.item() == bool_
+    assert xdata.str_.item() == str_
+    if not isinstance(mrun[0], list) and all(
+        isinstance(i, type(mrun[0])) for i in mrun
+    ):
+        assert xdata.mrun.data.tolist() == mrun
+    else:
+        assert xdata.mrun.data.tolist() == [str(i) for i in mrun]


### PR DESCRIPTION
Prior to this PR, override values of types other than `int` and `float` were automatically cast to strings when the workflow loaded/parsed the overrides (e.g. to form the xarray). This PR fixes that issue.

Additionally an override that specifies a sequence of values for a multirun is now returned specifically as a `multirun` list, enabling users to distinguish a multirun sequence of values vs a single override that happens to be a list.

Consider:

```python
from rai_toolbox.mushin import multirun, hydra_list

class WorkFlow(MultiRunMetricsWorkflow):
    @staticmethod
    def evaluation_task(*args, **kwargs):
        return None
```

Before PR:

```python
>>> wf = WorkFlow()
>>> wf.run(foo=hydra_list(["val"]), bar=multirun([False, True]), apple=1)
>>> wf.multirun_task_overrides
{'foo': "['val']", 'bar': ['False', 'True'], 'apple': 1}
```

After PR:

```python
>>> wf = WorkFlow()
>>> wf.run(foo=hydra_list(["val"]), bar=multirun([False, True]), apple=1)
>>> wf.multirun_task_overrides
{'foo': ['val'], 'bar': multirun([False, True]), 'apple': 1}
```