### PR TITLE
Enable user-specified functions for loading metrics files

### DIFF
--- a/docs/source/generated/rai_toolbox.mushin.MultiRunMetricsWorkflow.rst
+++ b/docs/source/generated/rai_toolbox.mushin.MultiRunMetricsWorkflow.rst
@@ -17,9 +17,10 @@ rai\_toolbox.mushin.MultiRunMetricsWorkflow
    
       ~MultiRunMetricsWorkflow.__init__
       ~MultiRunMetricsWorkflow.task
-      ~MultiRunMetricsWorkflow.jobs_post_process
-      ~MultiRunMetricsWorkflow.load_from_dir
-      ~MultiRunMetricsWorkflow.plot
       ~MultiRunMetricsWorkflow.run
+      ~MultiRunMetricsWorkflow.metric_load_fn
+      ~MultiRunMetricsWorkflow.load_from_dir
       ~MultiRunMetricsWorkflow.to_xarray
+      ~MultiRunMetricsWorkflow.jobs_post_process
+      ~MultiRunMetricsWorkflow.plot
       ~MultiRunMetricsWorkflow.validate

--- a/src/rai_toolbox/mushin/workflows.py
+++ b/src/rai_toolbox/mushin/workflows.py
@@ -826,6 +826,33 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
         Returns
         ------
         metrics : Dict[str, List[Any]]
+
+        Examples
+        --------
+        Creating a workflow that saves named metrics using `torch.save`
+
+        >>> from rai_toolbox.mushin.workflows import MultiRunMetricsWorkflow, multirun
+        >>> import torch as tr
+        >>>
+        ... class TorchWorkFlow(MultiRunMetricsWorkflow):
+        ...     @staticmethod
+        ...     def task(a, b):
+        ...         tr.save(dict(a=a, b=b), "metrics.pt")
+        ...
+        >>> wf = TorchWorkFlow()
+        >>> wf.run(a=multirun([1, 2, 3]), b=False)
+        [2022-06-01 12:35:51,650][HYDRA] Launching 3 jobs locally
+        [2022-06-01 12:35:51,650][HYDRA] 	#0 : +a=1 +b=False
+        [2022-06-01 12:35:51,715][HYDRA] 	#1 : +a=2 +b=False
+        [2022-06-01 12:35:51,780][HYDRA] 	#2 : +a=3 +b=False
+
+        `~MultiRunMetricsWorkflow` uses `torch.load` by default to load metrics files
+        (refer to `~MultiRunMetricsWorkflow.metric_load_fn` to change this behavior).
+
+        >>> wf.load_metrics("metrics.pt")
+        defaultdict(list, {'a': [1, 2, 3], 'b': [False, False, False]})
+        >>> wf.metrics
+        defaultdict(list, {'a': [1, 2, 3], 'b': [False, False, False]})
         """
         if self.multirun_working_dirs is None:
             self.load_from_dir(self.working_dir, metrics_filename=None)

--- a/src/rai_toolbox/mushin/workflows.py
+++ b/src/rai_toolbox/mushin/workflows.py
@@ -553,7 +553,8 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
 
     @staticmethod
     def task(*args: Any, **kwargs: Any) -> Mapping[str, Any]:  # pragma: no cover
-        """Abstract `staticmethod` for users to define the evalultion task"""
+        """Abstract `staticmethod` for users to define the task that is configured and
+        launched by the workflow"""
         raise NotImplementedError()
 
     def metric_load_fn(self, file_path: Path) -> Mapping[str, Any]:
@@ -569,7 +570,31 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
         Returns
         -------
         named_metrics : Mapping[str, Any]
-            metric-name -> metric-value(s)"""
+            metric-name -> metric-value(s)
+
+        Examples
+        --------
+        Designing a workflow that uses the `pickle` module to save and load
+        metrics
+
+        >>> from rai_toolbox.mushin import MultiRunMetricsWorkflow, multirun
+        >>> import pickle
+        >>>
+        >>> class PickledWorkFlow(MultiRunMetricsWorkflow):
+        ...     def metric_load_fn(self, file_path: Path):
+        ...         with file_path.open("rb") as f:
+        ...             return pickle.load(f)
+        ...
+        ...     @staticmethod
+        ...     def task(a, b):
+        ...         with open("./metrics.pkl", "wb") as f:
+        ...             pickle.dump(dict(a=a, b=b), f)
+        >>>
+        >>> wf = PickleWorkFlow()
+        >>> wf.run(a=multirun([1, 2, 3]), b=False)
+        >>> wf.load_metrics("metrics.pkl")
+        >>> wf.metrics
+        dict(a=[1, 2, 3], b=[False, False, False])"""
         return tr.load(file_path)
 
     def run(

--- a/src/rai_toolbox/mushin/workflows.py
+++ b/src/rai_toolbox/mushin/workflows.py
@@ -557,7 +557,8 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
         launched by the workflow"""
         raise NotImplementedError()
 
-    def metric_load_fn(self, file_path: Path) -> Mapping[str, Any]:
+    @staticmethod
+    def metric_load_fn(file_path: Path) -> Mapping[str, Any]:
         """Loads a metric file and returns a dictionary of metric-name -> metric-value
         mappings.
 
@@ -581,7 +582,8 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
         >>> import pickle
         >>>
         >>> class PickledWorkFlow(MultiRunMetricsWorkflow):
-        ...     def metric_load_fn(self, file_path: Path):
+        ...     @staticmethod
+        ...     def metric_load_fn(file_path: Path):
         ...         with file_path.open("rb") as f:
         ...             return pickle.load(f)
         ...


### PR DESCRIPTION
E.g. here is a workflow that uses `pickle` to save and load metrics (instead of relying of the default of `torch.load`:

```python
import pickle

class PickleWorkFlow(MultiRunMetricsWorkflow):
    def metric_load_fn(self, file_path: Path):
        with file_path.open("rb") as f:
            return pickle.load(f)

    @staticmethod
    def task(a, b):
        with open("./metrics.pkl", "wb") as f:
            pickle.dump(dict(a=[[a] * 2], b=b), f)
```