### PR TITLE
Fix TopQGradient device mismatch

### DIFF
--- a/src/rai_toolbox/optim/misc.py
+++ b/src/rai_toolbox/optim/misc.py
@@ -359,7 +359,11 @@ class TopQGradientOptimizer(ParamTransformingOptimizer):
             _qhigh = min(1.0, q + dq)
 
             q = float(
-                (_qhigh - _qlow) * torch.rand(1, generator=self._generator) + _qlow
+                (_qhigh - _qlow)
+                * torch.rand(
+                    1, generator=self._generator, device=self._generator.device
+                )
+                + _qlow
                 if dq and (_qlow < q or _qhigh > q)
                 else q
             )


### PR DESCRIPTION
Prior to the PR, the following would raise:

```python
from rai_toolbox.optim import TopQGradientOptimizer
import torch as tr

generator = tr.Generator(device="cuda:0")
x = tr.ones((2000,), requires_grad=True)
optim = TopQGradientOptimizer(
        params=[x], 
        generator=generator,
        q=0.5,
        dq=1.0,
        lr=1.0,
        param_ndim=None,
)
(x * 1).sum().backward()
optim.step()  # RuntimeError: Expected a 'cpu' device type for generator but found 'cuda'
```

This is caused by the fact that PyTorch's random functions are unwilling to infer device from their generator:

```python
gen= tr.Generator(device="cuda:0")
torch.rand(1, generator=gen) # RuntimeError: Expected a 'cpu' device type for generator but found 'cuda'
torch.rand(1, generator=gen, device=gen.device)  # OK
```

Edit: opened an issue on PyTorch: https://github.com/pytorch/pytorch/issues/79018