### PR TITLE
Fixes `to_xarray` when `target_job_dirs` points to job that performed multirun over sequence values

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -8,6 +8,16 @@ Changelog
 This is a record of all past rAI-toolbox releases and what went into them, in reverse 
 chronological order. All previous releases should still be available on pip.
 
+.. _v0.2.1:
+
+------------------
+0.2.1 - 2022-06-16
+------------------
+
+This patch fixes the following bugs:
+- ``TopQGradient`` device mismatch with user-specified RNG (see :pull:`64`)
+- `MultiRunMetricsWorkflow.to_xarray` raises `ValueError` when `target_job_dirs` points to job that performed a multirun over sequence-type values (see :pull:`68`)
+
 .. _v0.2.0:
 
 ------------------

--- a/tests/test_mushin/test_workflows.py
+++ b/tests/test_mushin/test_workflows.py
@@ -387,7 +387,12 @@ def test_multirun_over_jobdir(load_from_working_dir):
     # a multirun over the resulting folders, loading in
     # their metrics and re-returning them
     wf = FirstMultiRun()
-    wf.run(epsilon=multirun([1.0, 2.0, 3.0]), acc=multirun([1, 2]), working_dir="first")
+    wf.run(
+        epsilon=multirun([1.0, 2.0, 3.0]),
+        acc=multirun([1, 2]),
+        list_vals=multirun([[0, 1]]),  # ensure that multiruns over lists work
+        working_dir="first",
+    )
 
     snd_wf = ScndMultiRun()
     # runs over a total of epsilon-3 x acc-2 -> 6 job-dirs and 2 val
@@ -404,6 +409,7 @@ def test_multirun_over_jobdir(load_from_working_dir):
     assert snd_wf.target_dir_multirun_overrides == {
         "acc": [1, 1, 1, 2, 2, 2],
         "epsilon": [1.0, 2.0, 3.0, 1.0, 2.0, 3.0],
+        "list_vals": [[0, 1]] * 6,
     }
     xr1 = wf.to_xarray()
     xr2 = snd_wf.to_xarray()
@@ -411,16 +417,22 @@ def test_multirun_over_jobdir(load_from_working_dir):
     assert xr1.dims == {"acc": 2, "epsilon": 3, "images_dim0": 4, "images_dim1": 1}
     assert xr2.dims == {"val": 2, "job_dir": 6, "images_dim0": 4, "images_dim1": 1}
 
-    xr2 = xr2.set_index(job_dir=["epsilon", "acc"]).unstack("job_dir")
-    xr2 = xr2.transpose("val", "acc", "epsilon", "images_dim0", "images_dim1")
+    xr2 = xr2.set_index(job_dir=["epsilon", "acc", "list_vals"]).unstack("job_dir")
+    xr2 = xr2.transpose(
+        "list_vals", "val", "acc", "epsilon", "images_dim0", "images_dim1"
+    )
 
     assert_identical(xr1.epsilon, xr2.epsilon)
     assert_identical(xr1.acc, xr2.acc)
 
-    assert_duckarray_equal(xr1.images, xr2.images.sel(val=1))
-    assert_duckarray_equal(2 * xr1.images, xr2.images.sel(val=2))
-    assert_duckarray_equal(xr1.accuracies, xr2.accuracies.sel(val=1))
-    assert_duckarray_equal(2 * xr1.accuracies, xr2.accuracies.sel(val=2))
+    assert_duckarray_equal(xr1.images, xr2.images.sel(val=1, list_vals="[0, 1]"))
+    assert_duckarray_equal(2 * xr1.images, xr2.images.sel(val=2, list_vals="[0, 1]"))
+    assert_duckarray_equal(
+        xr1.accuracies, xr2.accuracies.sel(val=1, list_vals="[0, 1]")
+    )
+    assert_duckarray_equal(
+        2 * xr1.accuracies, xr2.accuracies.sel(val=2, list_vals="[0, 1]")
+    )
 
 
 class NoMetrics(MultiRunMetricsWorkflow):


### PR DESCRIPTION
Example:

```python
from rai_toolbox.mushin import MultiRunMetricsWorkflow, multirun


class Blank(MultiRunMetricsWorkflow):
    @staticmethod
    def task():
        pass
```

```python
wf1 = Blank()
wf1.run(
    list_vals=multirun([[0, 1], [2, 3]]),  # note: multi-run over list-values
    working_dir="first",
)

wf2 = Blank()
wf2.run(
    target_job_dirs=wf1.multirun_working_dirs,
    val=multirun([1, 2]),
    working_dir="second",
)
```

**Before:**

```python
>>> wf2.to_xarray()
ValueError!   
```

**After:**

```python
>>> wf2.to_xarray()
<xarray.Dataset>
Dimensions:    (val: 2, job_dir: 2)
Coordinates:
  * val        (val) int64 1 2
  * job_dir    (job_dir) <U61 '/home/some_path/...
    list_vals  (job_dir) <U6 '[0, 1]' '[2, 3]'
Data variables:
    *empty*
```