### PR TITLE
add `rai_experiments.models.pretrained.load_model` via pooch

### DIFF
--- a/experiments/src/rai_experiments/models/pretrained.py
+++ b/experiments/src/rai_experiments/models/pretrained.py
@@ -59,6 +59,7 @@ def load_model(
 
     import torch
     from torchvision import transforms
+    from torchvision.models import resnet50 as torchvision_resnet50
 
     from rai_toolbox.mushin._utils import load_from_checkpoint
 
@@ -74,6 +75,7 @@ def load_model(
     elif model_name in {
         "mitll_imagenet_l2_3_0.pt",
         "mitll_restricted_imagenet_l2_3_0.pt",
+        "imagenet_nat.pt",
     }:
 
         model = partial(resnet50, num_classes=9 if "restricted" in model_name else 1000)
@@ -86,11 +88,14 @@ def load_model(
             f"Unknown model name: {model_name}\nAvailable models: {', '.join(_pre_trained_manager.registry_files)}"
         )
 
-    base_model = load_from_checkpoint(
-        model=model(),
-        ckpt=_pre_trained_manager.fetch(model_name),
-        weights_key="state_dict",
-    )
+    if model_name == "imagenet_nat.pt":
+        base_model = torchvision_resnet50(pretrained=True)
+    else:
+        base_model = load_from_checkpoint(
+            model=model(),
+            ckpt=_pre_trained_manager.fetch(model_name),
+            weights_key="state_dict",
+        )
 
     model = torch.nn.Sequential(norm, base_model)
     return model

--- a/experiments/src/rai_experiments/models/pretrained.py
+++ b/experiments/src/rai_experiments/models/pretrained.py
@@ -46,10 +46,10 @@ def load_model(
     -----
     Descriptions of models:
 
-       - `mitll_cifar_nat.pt`: This is a ResNet-50 model trained on CIFAR 10 using standard training with no adversarial perturbations in the loop (i.e., :math:`\epsilon=0`)
-       - `mitll_cifar_l2_1_0.pt`: A ResNet-50 model trained on CIFAR 10 with perturbations generated via PGD using perturbations constrained to :math:`L^2`-ball of radius :math:`\epsilon=1.0`
-       -  `mitll_imagenet_l2_3_0`: This is a ResNet-50 model trained on ImageNet with PGD using :math:`\epsilon=3.0`
-       -  `mitll_restricted_imagenet_l2_3_0`: This is a ResNet-50 model trained on restricted ImageNet [2]_ with PGD using :math:`\epsilon=3.0`
+    - `mitll_cifar_nat.pt`: This is a ResNet-50 model trained on CIFAR 10 using standard training with no adversarial perturbations in the loop (i.e., :math:`\epsilon=0`)
+    - `mitll_cifar_l2_1_0.pt`: A ResNet-50 model trained on CIFAR 10 with perturbations generated via PGD using perturbations constrained to :math:`L^2`-ball of radius :math:`\epsilon=1.0`
+    -  `mitll_imagenet_l2_3_0`: This is a ResNet-50 model trained on ImageNet with PGD using :math:`\epsilon=3.0`
+    -  `mitll_restricted_imagenet_l2_3_0`: This is a ResNet-50 model trained on restricted ImageNet [2]_ with PGD using :math:`\epsilon=3.0`
 
     References
     ----------

--- a/experiments/src/rai_experiments/models/pretrained.py
+++ b/experiments/src/rai_experiments/models/pretrained.py
@@ -23,6 +23,8 @@ def load_model(
         "mitll_imagenet_l2_3_0.pt",
     ]
 ):
+    # TODO: Add docs
+
     # TODO: which architecture is correct for mitll_restricted_imagenet_l2_3_0?
 
     import torch
@@ -47,6 +49,9 @@ def load_model(
         ckpt=_pre_trained_manager.fetch(name),
         weights_key="state_dict",
     )
+
+    # TODO: is this normalization appropriate only for cifar10?
+
     # Transform to normalize the data samples by the mean and standard deviation
     normalizer = torchvision.transforms.transforms.Normalize(
         mean=[0.4914, 0.4822, 0.4465],

--- a/experiments/src/rai_experiments/models/pretrained.py
+++ b/experiments/src/rai_experiments/models/pretrained.py
@@ -24,6 +24,7 @@ def load_model(
         "mitll_cifar_nat.pt",
         "mitll_imagenet_l2_3_0.pt",
         "mitll_restricted_imagenet_l2_3_0.pt",
+        "imagenet_nat.pt",
     ]
 ):
     r"""
@@ -35,7 +36,13 @@ def load_model(
 
     Parameters
     ----------
-    model_name: Literal["mitll_cifar_l2_1_0.pt", "mitll_cifar_nat.pt", "mitll_imagenet_l2_3_0.pt", "mitll_restricted_imagenet_l2_3_0.pt"]
+    model_name: str
+        Supported models
+           - mitll_cifar_l2_1_0.pt
+           - mitll_cifar_nat.pt
+           - mitll_imagenet_l2_3_0.pt
+           - mitll_restricted_imagenet_l2_3_0.pt
+           - imagenet_nat.p
 
     Returns
     -------

--- a/experiments/src/rai_experiments/models/pretrained.py
+++ b/experiments/src/rai_experiments/models/pretrained.py
@@ -1,0 +1,56 @@
+import pooch
+from typing_extensions import Literal
+
+__all__ = ["load_model"]
+
+
+_pre_trained_manager = pooch.create(
+    path=pooch.os_cache("rai-experiments"),
+    base_url="https://github.com/mit-ll-responsible-ai/data_hosting/releases/download/madrylab_models/",
+    registry={
+        "mitll_cifar_l2_1_0.pt": "md5:738f109685dfc55f7227dc6dc473379e",
+        "mitll_cifar_nat.pt": "md5:34e15ff183735933e13f41ad27f755b4",
+        "mitll_restricted_imagenet_l2_3_0.pt": "md5:db37145acfd8bdf7ef7c05f4d261c0d9",
+        "mitll_imagenet_l2_3_0.pt": "md5:37728e5c9c47684c0edd373e9d80ac9b",
+    },
+)
+
+
+def load_model(
+    name: Literal[
+        "mitll_cifar_l2_1_0.pt",
+        "mitll_cifar_nat.pt",
+        "mitll_imagenet_l2_3_0.pt",
+    ]
+):
+    # TODO: which architecture is correct for mitll_restricted_imagenet_l2_3_0?
+
+    import torch
+    import torchvision
+
+    from rai_toolbox.mushin._utils import load_from_checkpoint
+
+    from ..models.resnet import resnet50
+    from ..models.small_resnet import resnet50 as small_resnet50
+
+    if name in {"mitll_cifar_l2_1_0.pt", "mitll_cifar_nat.pt"}:
+        model = small_resnet50
+    elif name in {"mitll_imagenet_l2_3_0.pt"}:
+        model = resnet50
+    else:
+        raise ValueError(
+            f"Unknown model name: {name}\nAvailable models: {', '.join(_pre_trained_manager.registry_files)}"
+        )
+
+    base_model = load_from_checkpoint(
+        model=model(),
+        ckpt=_pre_trained_manager.fetch(name),
+        weights_key="state_dict",
+    )
+    # Transform to normalize the data samples by the mean and standard deviation
+    normalizer = torchvision.transforms.transforms.Normalize(
+        mean=[0.4914, 0.4822, 0.4465],
+        std=[0.2023, 0.1994, 0.2010],
+    )
+    model = torch.nn.Sequential(normalizer, base_model)
+    return model

--- a/experiments/src/rai_experiments/models/pretrained.py
+++ b/experiments/src/rai_experiments/models/pretrained.py
@@ -92,7 +92,7 @@ def load_model(
         )
     else:
         raise ValueError(
-            f"Unknown model name: {model_name}\nAvailable models: {', '.join(_pre_trained_manager.registry_files)}"
+            f"Unknown model name: {model_name}\nAvailable models: {', '.join(_pre_trained_manager.registry_files + ['imagenet_nat.pt'])}"
         )
 
     if model_name == "imagenet_nat.pt":

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
             "hydra-zen >= 0.7.0",
             "xarray >= 0.19.0",
             "matplotlib >= 3.3",
+            "pooch >= 1.6.0",
             "protobuf <= 3.20.1",  # strict TODO: Remove after tensorboard gets compatible https://github.com/tensorflow/tensorboard/issues/5708
         ],
     },


### PR DESCRIPTION
Adds basic model checkpoint management using [pooch](https://www.fatiando.org/pooch/latest/index.html).

In tutorials, replace:
```python
# <instructions for manually downloading weights
ckpt = #... manually specified checkpoint path

# Function for loading model from checkpoint path
# and adding a pre-processing module to normalize
# the data by its mean and standard deviation
def load_model(ckpt):
    base_model = load_from_checkpoint(
        model = resnet50(),
        ckpt = ckpt,
        weights_key="state_dict",
    )
    # Transform to normalize the data samples by the mean and standard deviation
    normalizer = torchvision.transforms.transforms.Normalize(
        mean=[0.4914, 0.4822, 0.4465],
        std=[0.2023, 0.1994, 0.2010],
    )
    model = torch.nn.Sequential(normalizer, base_model)
    return model
```

With:

```python
from rai_experiments.models.pretrained import load_model

ckpt_robust = "mitll_cifar_l2_1_0.pt"

# downloads model weights to '/home/<username>/.cache/rai-experiments' unless already available
model_robust = load_model(ckpt_robust)
model_robust.eval();
```

Once this is merged we should update tutorials/experiments to use this utility