### PR TITLE
pyright: ignore pytorch lightning `__version__` not being exported properly

### DIFF
--- a/src/rai_toolbox/mushin/_compatibility.py
+++ b/src/rai_toolbox/mushin/_compatibility.py
@@ -28,4 +28,4 @@ def _get_version(ver_str: str) -> Version:
     return Version(major=major, minor=minor, patch=int(patch_str))
 
 
-PL_VERSION: Final = _get_version(pytorch_lightning.__version__)
+PL_VERSION: Final = _get_version(pytorch_lightning.__version__)  # type: ignore


### PR DESCRIPTION
Should fix failing nightly: https://github.com/mit-ll-responsible-ai/responsible-ai-toolbox/actions/runs/2786568555

Opened issue: https://github.com/Lightning-AI/lightning/issues/13996

