### PR TITLE
Add spellcheck and formatting requirements to CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-ignore = F811,D1,D205,D209,D213,D400,D401,D999,D202,E203,E501,W503,E721,F403,F405
+exclude = .git,__pycache__,docs/source/conf.py,tests/annotations

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -200,6 +200,21 @@ jobs:
     - name: Test with tox
       run: tox -e pre-release
 
+  check-repo-format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox -e enforce-format
+
   run-pyright:
     runs-on: ubuntu-latest
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,6 @@ repos:
     rev: 6.0.0
     hooks:
     - id: flake8
-      args: [--ignore, "F811,D1,D205,D209,D213,D400,D401,D999,D202,E203,E501,W503,E721,F403,F405",
-      --exclude, "docs/*,tests/annotations/*"]
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -31,7 +31,7 @@ Improvements to `MultiRunMetricsWorkflow`
 -----------------------------------------
 - A `pre_task` step can be defined for a workflow; this is useful for seeding random number generators prior to the task's instantiation phase. See :ref:`this how-to guide <how-to-deterministic>` for examples.
 - Loaded workflow overrides now roundtrip appropriately. See :pull:`61`.
-- `metric_load_fn` can be overriden to customize how `~MultiRunMetricsWorkflow` loads metric files; the default behavior is to use `torch.load`. See :pull:`63`.
+- `metric_load_fn` can be overridden to customize how `~MultiRunMetricsWorkflow` loads metric files; the default behavior is to use `torch.load`. See :pull:`63`.
 - `working_subdir` can be included as a data-variable in a workflow's xarray; this enables users to lookup subdirs by override values. See :pull:`52`.
 - `to_xarray` works on lists of array-likes, not just lists of numpy arrays
 - `load_metrics` can be called directly from `~MultiRunMetricsWorkflow`.
@@ -63,7 +63,7 @@ Deprecations
 This patch fixes two bugs in ``rai_toolbox.perturbations.init``:
 
 - `~rai_toolbox.perturbations.uniform_like_l1_n_ball_` was not correctly symmeterized; the drawn values only had components in the direction of the positive hemisphere of the :math:`L^1` ball.
-- Passing an on-gpu tensor to the in-place init functions would cause a device mis-match error with the default random number generator, which is on CPU.
+- Passing an on-gpu tensor to the in-place init functions would cause a device mismatch error with the default random number generator, which is on CPU.
 
 
 .. _v0.1.0:

--- a/docs/source/explanation/perturbations.rst
+++ b/docs/source/explanation/perturbations.rst
@@ -181,7 +181,7 @@ Common data-related workflows supported by rAI-toolbox
 ======================================================
 
 A wide range of responsible AI techniques involve optimizing parameters of data
-perturbations (or more generally, *transforations*), often in addition to optimizations over model parameters:
+perturbations (or more generally, *transformations*), often in addition to optimizations over model parameters:
 
 - Data augmentations / corruptions: :math:`g_\delta(x)`
     - Model-independent

--- a/docs/source/how_to/univ_adv_pert.rst
+++ b/docs/source/how_to/univ_adv_pert.rst
@@ -7,7 +7,7 @@
 Solve for a Universal Perturbation
 ==================================
 
-A universal adversarial perturbation (UAP) is a *single* perturbation that can be applied *uniformly to any data* in order to substantially reduce the quality of a machine learning model's predicitons on that data.
+A universal adversarial perturbation (UAP) is a *single* perturbation that can be applied *uniformly to any data* in order to substantially reduce the quality of a machine learning model's predictionsf on that data.
 In the case of an additive perturbation (i.e., :math:`x \rightarrow x + \delta`), the single perturbation, :math:`\delta`, is optimized over a data distribution:
 
 .. math::
@@ -16,7 +16,7 @@ In the case of an additive perturbation (i.e., :math:`x \rightarrow x + \delta`)
 
 The paper `Universal Adversarial Training <https://arxiv.org/pdf/1811.11304.pdf>`_ by Shafahi et al propose a simple and efficient gradient-based optimization method for solving for such a UAP.
 
-In this How-To, we demonstrate how the rAI-toolbox's perturbation models, optimizers, and solvers naturally accomodate this approach to solving for UAPs.
+In this How-To, we demonstrate how the rAI-toolbox's perturbation models, optimizers, and solvers naturally accommodate this approach to solving for UAPs.
 Specifically, we will
 
 1. Create some toy-data and a trivial model.
@@ -78,7 +78,7 @@ Rather than specifying the precise shape of the perturbation, we can simply indi
             [0., 0., 0., 0.]]], requires_grad=True)
 
 
-Now we will initialize an optimizer that will update our perturbation. `~rai_toolbox.optim.L2ProjectedOptim` is designed to normalize a gradient by its :math:`L^2` norm prior to perfoming the parameter updated (using a `SGD` step by default). The updated perturbation is then projected into a :math:`\epsilon`-sized :math:`L^2` ball.
+Now we will initialize an optimizer that will update our perturbation. `~rai_toolbox.optim.L2ProjectedOptim` is designed to normalize a gradient by its :math:`L^2` norm prior to performing the parameter updated (using a `SGD` step by default). The updated perturbation is then projected into a :math:`\epsilon`-sized :math:`L^2` ball.
 We will use an `SGD` step with `lr=0.1` and a momentum of 0.9; we pick :math:`\epsilon=2`. In order to ensure that these gradient and parameter-transforming operations apply appropriately to our UAP, we specify `param_ndim=None` (see :ref:`these docs <param-ndim-add>` for more details).
 
 
@@ -168,7 +168,7 @@ Let's check that the loss of the clean batch of data is less than the loss of th
    >>> cross_entropy(model(pert_data), truth)
    tensor(2.4227, grad_fn=<NllLossBackward0>)
 
-Great! Our UAP for this toy problem reduces the average perfomance of our model on uniformally-perturbed data.
+Great! Our UAP for this toy problem reduces the average performance of our model on uniformally-perturbed data.
 
 .. note:: 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ combine_as_imports = true
 omit = ["src/rai_toolbox/_version.py"]
 
 
+[tool.codespell]
+skip = '*.js,*.html,*ipynb,*.svg,*.css,docs/build'
+
 
 [tool.pyright]
 include = ["src"]
@@ -162,6 +165,30 @@ extras =
     mushin
 basepython = python3.8
 
+[testenv:auto-format]
+skip_install=true
+deps =
+    autoflake
+    black
+    isort
+commands =
+    autoflake --recursive --in-place --remove-duplicate-keys --remove-unused-variables src/ tests/
+    isort src/ tests/
+    black src/ tests/
+
+[testenv:enforce-format]
+skip_install=true
+basepython=python3.9
+deps=black
+     isort
+     flake8
+     codespell
+commands=
+    black src/ tests/ --diff --check
+    isort src/ tests/ --diff --check
+    flake8 src/ tests/
+    codespell src/ docs/
+
 
 # runs experiments that don't require additional dependencies
 [testenv:experiments-checks]
@@ -177,3 +204,4 @@ commands =
    pytest experiments/universal_perturbation/test_experiment.py
    pytest experiments/xai/test_experiment.py
 """
+

--- a/src/rai_toolbox/_typing.py
+++ b/src/rai_toolbox/_typing.py
@@ -95,7 +95,7 @@ def _is_protocol(cls: Any) -> bool:
 def instantiates_to(x: Any, co_var_type: Type[T]) -> TypeGuard[InstantiatesTo[T]]:
     """Checks if `x(...)` will return type `co_var_type`.
 
-    Accomodates structural subtyping via protocols.
+    Accommodates structural subtyping via protocols.
 
     Parameters
     ----------

--- a/src/rai_toolbox/_utils/tqdm.py
+++ b/src/rai_toolbox/_utils/tqdm.py
@@ -8,6 +8,7 @@ _T = TypeVar("_T", bound=Iterable)
 
 __all__ = ["tqdm"]
 
+
 def _dummy_tqdm(
     iterable: _T,
     desc: Optional[str] = None,
@@ -31,9 +32,9 @@ def _dummy_tqdm(
     unit_divisor=1000,
 ) -> _T:
     return iterable
-        
+
+
 try:
     from tqdm.auto import tqdm
 except ImportError:  # pragma: no cover
     tqdm = _dummy_tqdm
-

--- a/src/rai_toolbox/augmentations/fourier/_fourier_basis.py
+++ b/src/rai_toolbox/augmentations/fourier/_fourier_basis.py
@@ -10,7 +10,7 @@ from numpy.typing import DTypeLike
 
 
 class FourierBasis(NamedTuple):
-    """
+    r"""
     Describes a 2D planewave generated via:
 
     A * cos(2pi * freq_vector @ x + phase_shift)
@@ -51,7 +51,7 @@ def generate_fourier_bases(
     factor_2pi_phase_shift: float = 0,
     row_col_coords: Optional[Iterable[Tuple[int, int]]] = None,
 ) -> Iterator[FourierBasis]:
-    """Yields each unique, real-valued 2D array with unit norm, such that its Fourier
+    r"""Yields each unique, real-valued 2D array with unit norm, such that its Fourier
     transform is supported at each (i, j) and its symmetric position on a shape-(nrows, ncols)
     grid in Fourier space, where the lowest frequency component resides at the center of
     the grid.

--- a/src/rai_toolbox/augmentations/fourier/_implementations.py
+++ b/src/rai_toolbox/augmentations/fourier/_implementations.py
@@ -139,7 +139,7 @@ def create_heatmaps(
     factor_2pi_phase_shift: float = 0,
 ) -> Dict[str, List[HeatMapEntry]]:
     from rai_toolbox._utils.tqdm import tqdm
-    
+
     _outer_total = (
         None if row_col_coords is not None else int(np.prod(image_height_width)) // 2
     )

--- a/src/rai_toolbox/datasets/_utils.py
+++ b/src/rai_toolbox/datasets/_utils.py
@@ -10,7 +10,7 @@ PathLike = Union[str, Path]
 __all__ = ["md5_check"]
 
 
-def md5_check(fname: PathLike, chunksize: int = 1024 ** 2) -> str:
+def md5_check(fname: PathLike, chunksize: int = 1024**2) -> str:
     """Reads in data from disk and returns md5 hash"""
     import hashlib
 

--- a/src/rai_toolbox/losses/_jensen_shannon_divergence.py
+++ b/src/rai_toolbox/losses/_jensen_shannon_divergence.py
@@ -13,7 +13,7 @@ from rai_toolbox._typing import ArrayLike
 def jensen_shannon_divergence(
     *probs: ArrayLike, weight: Optional[float] = None
 ) -> tr.Tensor:
-    """
+    r"""
     Computes the Jensen-Shannon divergence [1]_ between n distributions:
 
     :math:`JSD(P_1, P_2, ..., P_n)`

--- a/src/rai_toolbox/mushin/hydra.py
+++ b/src/rai_toolbox/mushin/hydra.py
@@ -49,7 +49,7 @@ def _flat_call(x: Iterable[Callable[P, Any]]):
 
 # TODO: - zen's instantiation should be memoized so that subsequent access
 #         to an attribute returns the same instance
-#       - zen should interface with a singelton that "recognizes"
+#       - zen should interface with a singleton that "recognizes"
 #         the configs that it interacts with
 class Zen(Generic[P, T1]):
     def __init__(

--- a/src/rai_toolbox/mushin/workflows.py
+++ b/src/rai_toolbox/mushin/workflows.py
@@ -56,14 +56,10 @@ _VERSION_BASE_DEFAULT = _NotSet if HYDRA_VERSION < (1, 2, 0) else "1.1"
 class multirun(UserList):
     """Signals that a sequence is to be iterated over in a multirun"""
 
-    pass
-
 
 class hydra_list(UserList):
     """Signals that a sequence is provided as a single configured value (i.e. it is not
     to be iterated over during a multirun)"""
-
-    pass
 
 
 def _sort_x_by_k(x: T, k: Iterable[Any]) -> T:
@@ -243,9 +239,8 @@ class BaseWorkflow:
         -----
         This function is automatically wrapped by `zen`, which is responsible
         for parsing the function's signature and then extracting and instantiating
-        the correspending fields from a Hydra config object – passing them to the
+        the corresponding fields from a Hydra config object – passing them to the
         function. This behavior can be modified by `self.run(pre_task_fn_wrapper=...)`"""
-        pass
 
     @staticmethod
     def task(*args: Any, **kwargs: Any) -> Any:
@@ -271,13 +266,13 @@ class BaseWorkflow:
         -----
         This function is automatically wrapped by `zen`, which is responsible
         for parsing the function's signature and then extracting and instantiating
-        the correspending fields from a Hydra config object – passing them to the
+        the corresponding fields from a Hydra config object – passing them to the
         function. This behavior can be modified by `self.run(task_fn_wrapper=...)`
         """
         raise NotImplementedError()
 
     def validate(self, include_pre_task: bool = True):
-        """Valide the configuration will execute with the user defined evaluation task"""
+        """Validates that the configuration will execute with the user-defined evaluation task"""
         if include_pre_task:
             zen(self.pre_task).validate(self.eval_task_cfg)
 
@@ -458,7 +453,7 @@ class MultiRunMetricsWorkflow(BaseWorkflow):
     """Abstract class for workflows that record metrics using Hydra multirun.
 
     This workflow creates subdirectories of multirun experiments using Hydra.  These directories
-    contain the Hydra YAML configuration and any saved metrics file (defined by the evaulation task)::
+    contain the Hydra YAML configuration and any saved metrics file (defined by the evaluationf task)::
 
         ├── working_dir
         │    ├── <experiment directory name: 0>
@@ -1096,7 +1091,7 @@ class RobustnessCurve(MultiRunMetricsWorkflow):
             These parameters represent the values for configurations to use for the
             experiment.
 
-            These values will be appeneded to the `overrides` for the Hydra job.
+            These values will be appended to the `overrides` for the Hydra job.
         """
 
         if not isinstance(epsilon, str):

--- a/src/rai_toolbox/optim/lp_space.py
+++ b/src/rai_toolbox/optim/lp_space.py
@@ -10,8 +10,7 @@ from torch import Generator, Tensor, default_generator
 from torch.optim import SGD
 from typing_extensions import Final
 
-from rai_toolbox._typing import Optimizer as Opt
-from rai_toolbox._typing import OptimizerType, OptimParams, Partial
+from rai_toolbox._typing import Optimizer as Opt, OptimizerType, OptimParams, Partial
 from rai_toolbox._utils import check_param_group_value, value_check
 
 from .misc import TopQGradientOptimizer

--- a/src/rai_toolbox/optim/misc.py
+++ b/src/rai_toolbox/optim/misc.py
@@ -9,8 +9,7 @@ import torch
 from torch import Generator, Tensor, default_generator
 from torch.optim import SGD
 
-from rai_toolbox._typing import Optimizer as Opt
-from rai_toolbox._typing import OptimizerType, OptimParams, Partial
+from rai_toolbox._typing import Optimizer as Opt, OptimizerType, OptimParams, Partial
 from rai_toolbox._utils import check_param_group_value, value_check
 
 from .optimizer import REQUIRED, DatumParamGroup, ParamTransformingOptimizer
@@ -70,7 +69,7 @@ class _ClampedOptim(ParamTransformingOptimizer):
             Specifies default parameters for all parameter groups.
 
         param_ndim : Optional[int]
-            Controles how `_pre_step_transform_` and `_post_step_transform_`  are
+            Controls how `_pre_step_transform_` and `_post_step_transform_`  are
             broadcast onto a given parameter. This has no effect for
             `ClampedGradientOptimizer` and `ClampedParameterOptimizer`.
 
@@ -167,7 +166,7 @@ class ClampedParameterOptimizer(_ClampedOptim):
 
 class TopQGradientOptimizer(ParamTransformingOptimizer):
     """A gradient-tranforming  optimizer that zeros the elements of a gradient whose
-    absolue magnitudes fall below the Qth percentile. `InnerOpt.step()` is then to
+    absolute magnitudes fall below the Qth percentile. `InnerOpt.step()` is then to
     update the corresponding parameter.
 
     See Also

--- a/src/rai_toolbox/perturbations/__init__.py
+++ b/src/rai_toolbox/perturbations/__init__.py
@@ -2,12 +2,12 @@
 # Subject to FAR 52.227-11 – Patent Rights – Ownership by the Contractor (May 2014).
 # SPDX-License-Identifier: MIT
 
-from .models import AdditivePerturbation, PerturbationModel
 from .init import (
     uniform_like_l1_n_ball_,
     uniform_like_l2_n_ball_,
     uniform_like_linf_n_ball_,
 )
+from .models import AdditivePerturbation, PerturbationModel
 from .solvers import gradient_ascent, random_restart
 
 __all__ = [

--- a/src/rai_toolbox/perturbations/init.py
+++ b/src/rai_toolbox/perturbations/init.py
@@ -7,9 +7,11 @@ from typing import Optional, Union
 import torch
 from torch import Generator, Tensor, default_generator
 
-from rai_toolbox._utils import to_batch as _to_batch
-from rai_toolbox._utils import validate_param_ndim as _validate_param_ndim
-from rai_toolbox._utils import value_check
+from rai_toolbox._utils import (
+    to_batch as _to_batch,
+    validate_param_ndim as _validate_param_ndim,
+    value_check,
+)
 
 
 @torch.no_grad()
@@ -28,13 +30,13 @@ def uniform_like_l1_n_ball_(
         similar shape and on the same device.
 
         By default, each of the `N` shape-`(D, ...)` subtensors are initialized
-        independently. See `param_ndim` to contol this behavior.
+        independently. See `param_ndim` to control this behavior.
 
     epsilon : float, optional (default=1)
         Determines the radius of the ball.
 
     param_ndim : int | None, optional (default=-1)
-        Determines the dimenionality of the subtensors that are sampled by this
+        Determines the dimensionality of the subtensors that are sampled by this
         function.
 
         - A positive number determines the dimensionality of each subtensor to be drawn and packed into the shape-`(N, D, ...)` resulting tensor.
@@ -123,13 +125,13 @@ def uniform_like_l2_n_ball_(
         similar shape and on the same device.
 
         By default, each of the `N` shape-`(D, ...)` subtensors are initialized
-        independently. See `param_ndim` to contol this behavior.
+        independently. See `param_ndim` to control this behavior.
 
     epsilon : float, optional (default=1)
         Determines the radius of the ball.
 
     param_ndim : int | None, optional (default=-1)
-        Determines the dimenionality of the subtensors that are sampled by this
+        Determines the dimensionality of the subtensors that are sampled by this
         function.
 
         - A positive number determines the dimensionality of each subtensor to be drawn and packed into the shape-`(N, D, ...)` resulting tensor.

--- a/src/rai_toolbox/perturbations/solvers.py
+++ b/src/rai_toolbox/perturbations/solvers.py
@@ -53,7 +53,7 @@ def gradient_ascent(
 
     Note that, by default, this perturbs the data away from `target` (i.e., this performs
     gradient *ascent*), given a standard loss function that seeks to minimize the
-    diffence between the model's output and the target. See `targeted` to toggle this
+    difference between the model's output and the target. See `targeted` to toggle this
     behavior.
 
     Parameters
@@ -247,7 +247,7 @@ def gradient_ascent(
         if instantiates_to(perturbation_model, PerturbationModel):
             raise TypeError(
                 "An initialized optimizer can only be passed to the solver in "
-                "combination with an intialized perturbation model."
+                "combination with an initialized perturbation model."
             )
         if optim_kwargs:
             raise TypeError(
@@ -286,7 +286,7 @@ def gradient_ascent(
                     or losses.shape != data.shape[: losses.ndim]
                 ):
                     raise ValueError(
-                        f"`use_best=True` but `criterion` does not ouput a per-datum-loss. "
+                        f"`use_best=True` but `criterion` does not output a per-datum-loss. "
                         f"I.e. `criterion` returned a tensor of shape-{tuple(losses.shape)} for a "
                         f"batch of shape-{tuple(data.shape)}. Expected a tensor of "
                         f"shape-{(len(data),)} or greater."

--- a/tests/test_augmix/test_losses.py
+++ b/tests/test_augmix/test_losses.py
@@ -2,12 +2,11 @@
 # Subject to FAR 52.227-11 – Patent Rights – Ownership by the Contractor (May 2014).
 # SPDX-License-Identifier: MIT
 
-import pytest
 import hypothesis.strategies as st
-from hypothesis import settings
 import numpy as np
+import pytest
 import torch as tr
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.extra.numpy import array_shapes, arrays
 from mygrad import no_autodiff
 from mygrad.nnet.activations import softmax

--- a/tests/test_augmix/test_transforms.py
+++ b/tests/test_augmix/test_transforms.py
@@ -1,17 +1,15 @@
 # Copyright 2022, MASSACHUSETTS INSTITUTE OF TECHNOLOGY
 # Subject to FAR 52.227-11 – Patent Rights – Ownership by the Contractor (May 2014).
 # SPDX-License-Identifier: MIT
-import pytest
-
 from typing import Tuple, Union
 
 import hypothesis.strategies as st
-from hypothesis import settings
 import numpy as np
-from hypothesis import given
+import pytest
+from hypothesis import given, settings
 from numpy.testing import assert_allclose
 
-from rai_toolbox.augmentations.augmix import augment_and_mix, AugMix, Fork
+from rai_toolbox.augmentations.augmix import AugMix, Fork, augment_and_mix
 
 
 @given(
@@ -88,6 +86,7 @@ def identity1(x):
 def identity2(x):
     return x
 
+
 @settings(max_examples=10)
 @given(
     augmentations=st.lists(
@@ -97,12 +96,14 @@ def identity2(x):
 def test_augmix_reprs(augmentations):
     assert isinstance(repr(AugMix(identity1, augmentations=augmentations)), str)
 
+
 @settings(max_examples=10)
 @given(
     functions=st.lists(st.sampled_from([identity1, identity2]), min_size=1, max_size=7)
 )
 def test_fork_repr(functions):
     assert isinstance(repr(Fork(*functions)), str)
+
 
 @settings(max_examples=10)
 @given(bad_input=st.sampled_from([[], [1], [identity1, False], [True, identity1]]))

--- a/tests/test_mushin/test_zen.py
+++ b/tests/test_mushin/test_zen.py
@@ -4,8 +4,7 @@
 import pytest
 from hydra_zen import builds, make_config
 from hydra_zen.errors import HydraZenValidationError
-from hypothesis import given
-from hypothesis import strategies as st
+from hypothesis import given, strategies as st
 
 from rai_toolbox.mushin.hydra import zen
 

--- a/tests/test_perturbations/test_models.py
+++ b/tests/test_perturbations/test_models.py
@@ -7,8 +7,7 @@ from functools import partial
 import numpy as np
 import pytest
 import torch as tr
-from hypothesis import given, settings
-from hypothesis import strategies as st
+from hypothesis import given, settings, strategies as st
 from hypothesis.extra import numpy as hnp
 from omegaconf import ListConfig
 from torch.testing import assert_allclose

--- a/tests/test_perturbations/test_solvers.py
+++ b/tests/test_perturbations/test_solvers.py
@@ -8,12 +8,10 @@ import numpy as np
 import pytest
 import torch
 import torch as tr
-from hypothesis import given, settings
-from hypothesis import strategies as st
+from hypothesis import given, settings, strategies as st
 from hypothesis.extra import numpy as hnp
 from torch import Tensor
-from torch.nn import Module
-from torch.nn import functional as F
+from torch.nn import Module, functional as F
 from torch.optim import SGD
 
 from rai_toolbox.optim import L2ProjectedOptim, LinfProjectedOptim

--- a/tests/test_utils/test_other_utils.py
+++ b/tests/test_utils/test_other_utils.py
@@ -5,12 +5,10 @@
 import hypothesis.strategies as st
 import torch as tr
 from hypothesis import given, settings
+from torch.nn import Module
 
 from rai_toolbox._utils import get_device
 from rai_toolbox._utils.tqdm import _dummy_tqdm
-
-
-from torch.nn import Module
 
 devices = [tr.device("cpu")]
 
@@ -21,6 +19,7 @@ if tr.cuda.is_available():
 class EmptyModule(Module):
     def parameters(self, recurse: bool = True):
         return []
+
 
 @settings(deadline=None)
 @given(
@@ -33,6 +32,7 @@ def test_get_device(device, obj):
 
 def test_get_device_for_empty_module():
     assert get_device(EmptyModule()) == tr.device("cpu")
+
 
 @given(st.integers(0, 10))
 def test_tqdm(n: int):


### PR DESCRIPTION
CI will now fail if:
- code does not adhere to black and isort formatting
- flak8 scan fails
- codespell finds typos in src or docs