### PR TITLE
Housekeeping

### DIFF
--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .tox
-        key: tox-td${{ env.TIME_PERIOD }}-py${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
+        key: tox-td${{ env.TIME_PERIOD }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.github/workflows/tox.yml') }}
 
     - name: Test with tox
       run: tox -e py
@@ -70,7 +70,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .tox
-        key: tox-windows-td${{ env.TIME_PERIOD }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
+        key: tox-windows-td${{ env.TIME_PERIOD }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
 
     - name: Test with tox
       run: tox -e py38
@@ -99,7 +99,7 @@ jobs:
       with:
         path: .tox
 
-        key: tox-coverage-td${{ env.TIME_PERIOD }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
+        key: tox-coverage-td${{ env.TIME_PERIOD }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.github/workflows/tox.yml') }}
 
     - name: Measure coverage
       run: tox -e coverage
@@ -124,9 +124,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .tox
-        # setup.cfg and pyproject.toml have versioning info that would
+        # pyproject.toml and pyproject.toml have versioning info that would
         # impact the tox environment.
-        key: tox-experiments-${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
+        key: tox-experiments-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
 
     - name: Run experiments checks
       run: tox -e experiments-checks
@@ -151,7 +151,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .tox
-        key: tox-no-mushin-${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
+        key: tox-no-mushin-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
 
     - name: Run experiments checks
       run: tox -e no-mushin
@@ -174,7 +174,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .tox
-        key: tox-min-deps-${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
+        key: tox-min-deps-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
     - name: Test with tox
       run: tox -e min-deps
 
@@ -196,7 +196,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .tox
-        key: tox-pre-deps-${{ hashFiles('setup.cfg') }}-${{ hashFiles('setup.py') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
+        key: tox-pre-deps-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
     - name: Test with tox
       run: tox -e pre-release
 
@@ -247,7 +247,7 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: ${{ env.pythonLocation }}
-        key: pyright-td${{ env.WEEK_PERIOD }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
+        key: pyright-td${{ env.WEEK_PERIOD }}-${{ env.pythonLocation }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
       fail-fast: false
@@ -53,10 +53,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -73,7 +73,7 @@ jobs:
         key: tox-windows-td${{ env.TIME_PERIOD }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tests/conftest.py') }}-${{ hashFiles('.github/workflows/tox.yml') }}
 
     - name: Test with tox
-      run: tox -e py38
+      run: tox -e py310
 
   coverage:
     runs-on: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     
     - name: Install dependencies
       run: |
@@ -112,7 +112,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     
     - name: Install dependencies
       run: |
@@ -139,7 +139,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     
     - name: Install dependencies
       run: |
@@ -186,7 +186,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -241,7 +241,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Reset caching
       run: python -c "import time; weeks = time.time() / 60 / 60 / 24 / 7; print(f'WEEK_PERIOD=d{int(weeks / 2) * 2}')" >> $GITHUB_ENV
     - uses: actions/cache@v3

--- a/.github/workflows/tox_run.yml
+++ b/.github/workflows/tox_run.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/pypi/v/rai-toolbox.svg" alt="PyPI" />
   </a>
   <a>
-    <img src="https://img.shields.io/badge/python-3.7%20&#8208;%203.9-blue.svg" alt="Python version support" />
+    <img src="https://img.shields.io/badge/python-3.7%20&#8208;%203.11-blue.svg" alt="Python version support" />
   </a>
   <a href="https://github.com/mit-ll-responsible-ai/responsible-ai-toolbox/actions?query=workflow%3ATests+branch%3Amain">
     <img src="https://github.com/mit-ll-responsible-ai/responsible-ai-toolbox/workflows/Tests/badge.svg" alt="GitHub Actions" />

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/pypi/v/rai-toolbox.svg" alt="PyPI" />
   </a>
   <a>
-    <img src="https://img.shields.io/badge/python-3.7%20&#8208;%203.11-blue.svg" alt="Python version support" />
+    <img src="https://img.shields.io/badge/python-3.7%20&#8208;%203.10-blue.svg" alt="Python version support" />
   </a>
   <a href="https://github.com/mit-ll-responsible-ai/responsible-ai-toolbox/actions?query=workflow%3ATests+branch%3Amain">
     <img src="https://github.com/mit-ll-responsible-ai/responsible-ai-toolbox/workflows/Tests/badge.svg" alt="GitHub Actions" />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ basepython = python3.9
 extras = 
     tests
     mushin
+    datasets
 deps = {[testenv]deps}
        coverage
        pytest-cov
@@ -168,6 +169,7 @@ pip_pre = true
 extras = 
     tests
     mushin
+    datasets
 basepython = python3.9
 
 [testenv:auto-format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,13 @@ reportUnnecessaryTypeIgnoreComment = true
 reportUnnecessaryIsInstance = false
 
 
+[tool.pytest.ini_options]
+xfail_strict=true
+filterwarnings = [
+   "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning",
+ ]
+
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]
@@ -135,6 +142,7 @@ commands = pytest -n auto --hypothesis-profile ci tests
 [testenv:min-deps]  # test against minimum dependency versions
 deps = 
     {[testenv]deps}
+    setuptools==59.5.0
     torch==1.10.0
     torchmetrics==0.6.0
     typing-extensions==4.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [build-system]
-requires = [ "setuptools >= 35.0.2", "wheel >= 0.29.0", "setuptools_scm[toml]==7.0.5"]
+requires = [
+    "setuptools >= 35.0.2",
+    "wheel >= 0.29.0",
+    "setuptools_scm[toml]==7.0.5",
+]
 build-backend = "setuptools.build_meta"
-
 
 
 [project]
@@ -10,25 +13,22 @@ dynamic = ["version"]
 description = "PyTorch-centric library for evaluating and enhancing the robustness of AI technologies"
 readme = "README.md"
 requires-python = ">=3.7"
-dependencies=[
-    "torchvision >= 0.10.0",
+dependencies = [
     # pytorch 1.9.1 has bug for its view inplace-update checks
     "torch >= 1.9.0, != 1.9.1",
     "torchmetrics >= 0.6.0",
     "typing-extensions >= 4.1.1",
 ]
-license = {file = "LICENSE.txt"}
-keywords= [ "machine learning", "robustness", "pytorch", "responsible", "AI"]
+license = { file = "LICENSE.txt" }
+keywords = ["machine learning", "robustness", "pytorch", "responsible", "AI"]
 
 authors = [
-  {name = "Ryan Soklaski", email = "ryan.soklaski@ll.mit.edu" },
-  {name = "Justin Goodwin", email = "jgoodwin@ll.mit.edu" },
-  {name = "Olivia Brown"},
-  {name = "Michael Yee"}
+    { name = "Ryan Soklaski", email = "ryan.soklaski@ll.mit.edu" },
+    { name = "Justin Goodwin", email = "jgoodwin@ll.mit.edu" },
+    { name = "Olivia Brown" },
+    { name = "Michael Yee" },
 ]
-maintainers = [
-  {name = "Ryan Soklaski", email = "ryan.soklaski@ll.mit.edu" },
-]
+maintainers = [{ name = "Ryan Soklaski", email = "ryan.soklaski@ll.mit.edu" }]
 
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -53,12 +53,15 @@ tests = [
     "netCDF4 >= 1.5.8",
 ]
 
-mushin = ["pytorch-lightning >= 1.5.0",
-          "hydra-zen >= 0.9.0",
-          "xarray >= 0.19.0",
-          "matplotlib >= 3.3",
-          "protobuf <= 3.20.1",  # strict TODO: Remove after tensorboard gets compatible https://github.com/tensorflow/tensorboard/issues/5708
-        ]
+mushin = [
+    "pytorch-lightning >= 1.5.0",
+    "hydra-zen >= 0.9.0",
+    "xarray >= 0.19.0",
+    "matplotlib >= 3.3",
+    "protobuf <= 3.20.1",         # strict TODO: Remove after tensorboard gets compatible https://github.com/tensorflow/tensorboard/issues/5708
+]
+
+datasets = ["torchvision >= 0.10.0"]
 
 [project.urls]
 "Homepage" = "https://mit-ll-responsible-ai.github.io/responsible-ai-toolbox/"
@@ -66,15 +69,13 @@ mushin = ["pytorch-lightning >= 1.5.0",
 "Source" = "https://github.com/mit-ll-responsible-ai/responsible-ai-toolbox"
 
 
-
 [tool.setuptools_scm]
 write_to = "src/rai_toolbox/_version.py"
 version_scheme = "no-guess-dev"
 
 
-
 [tool.setuptools]
-package-dir = {"" = "src"}
+package-dir = { "" = "src" }
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -84,12 +85,10 @@ exclude = ["tests*", "tests.*"]
 rai_toolbox = ["py.typed"]
 
 
-
 [tool.isort]
 known_first_party = ["rai_toolbox", "tests", "rai_experiments"]
 profile = "black"
 combine_as_imports = true
-
 
 
 [tool.coverage.report]
@@ -103,16 +102,15 @@ skip = '*.js,*.html,*ipynb,*.svg,*.css,docs/build'
 [tool.pyright]
 include = ["src"]
 exclude = [
-       "**/node_modules",
-       "**/__pycache__",
-       "src/rai_toolbox/_version.py",
-       "**/third_party",
-       "**/project_tooling",
-       "./tests/test_augmentations/_old_implementation.py"
+    "**/node_modules",
+    "**/__pycache__",
+    "src/rai_toolbox/_version.py",
+    "**/third_party",
+    "**/project_tooling",
+    "./tests/test_augmentations/_old_implementation.py",
 ]
 reportUnnecessaryTypeIgnoreComment = true
 reportUnnecessaryIsInstance = false
-
 
 
 [tool.tox]
@@ -204,6 +202,7 @@ commands=
 basepython = python3.9
 extras = 
     tests
+    datasets
 deps = 
        experiments/
 commands = 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ description = "PyTorch-centric library for evaluating and enhancing the robustne
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    # pytorch 1.9.1 has bug for its view inplace-update checks
-    "torch >= 1.9.0, != 1.9.1",
+    "torch >= 1.10.0",
     "torchmetrics >= 0.6.0",
     "typing-extensions >= 4.1.1",
 ]
@@ -117,7 +116,7 @@ reportUnnecessaryIsInstance = false
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = py37, py38, py39, py310, py311
+envlist = py37, py38, py39, py310
 
 [gh-actions]
 python =
@@ -125,7 +124,6 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
-  3.11: py311
 
 [testenv]
 deps = pytest-xdist
@@ -137,7 +135,7 @@ commands = pytest -n auto --hypothesis-profile ci tests
 [testenv:min-deps]  # test against minimum dependency versions
 deps = 
     {[testenv]deps}
-    torch==1.9.0
+    torch==1.10.0
     torchmetrics==0.6.0
     typing-extensions==4.1.1
     hydra-zen==0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python :: 3 :: Only",
 ]
@@ -52,7 +54,7 @@ tests = [
 ]
 
 mushin = ["pytorch-lightning >= 1.5.0",
-          "hydra-zen >= 0.7.0",
+          "hydra-zen >= 0.9.0",
           "xarray >= 0.19.0",
           "matplotlib >= 3.3",
           "protobuf <= 3.20.1",  # strict TODO: Remove after tensorboard gets compatible https://github.com/tensorflow/tensorboard/issues/5708
@@ -117,13 +119,15 @@ reportUnnecessaryIsInstance = false
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = py37, py38, py39
+envlist = py37, py38, py39, py310, py311
 
 [gh-actions]
 python =
   3.7: py37
   3.8: py38
   3.9: py39
+  3.10: py310
+  3.11: py311
 
 [testenv]
 deps = pytest-xdist
@@ -151,7 +155,7 @@ commands = pytest -n auto --hypothesis-profile ci tests
 [testenv:coverage]
 setenv = NUMBA_DISABLE_JIT=1
 usedevelop = true
-basepython = python3.8
+basepython = python3.9
 extras = 
     tests
     mushin
@@ -166,7 +170,7 @@ pip_pre = true
 extras = 
     tests
     mushin
-basepython = python3.8
+basepython = python3.9
 
 [testenv:auto-format]
 skip_install=true
@@ -197,7 +201,7 @@ commands=
 
 # runs experiments that don't require additional dependencies
 [testenv:experiments-checks]
-basepython = python3.8
+basepython = python3.9
 extras = 
     tests
 deps = 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python :: 3 :: Only",
 ]
@@ -110,12 +109,16 @@ exclude = [
 ]
 reportUnnecessaryTypeIgnoreComment = true
 reportUnnecessaryIsInstance = false
+reportPrivateImportUsage = false
 
 
 [tool.pytest.ini_options]
 xfail_strict=true
 filterwarnings = [
    "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning",
+   "ignore:Future Hydra versions will no longer change working directory at job runtime by default.",
+   "ignore:distutils Version classes are deprecated",
+   "ignore:numpy.ndarray size changed, may indicate binary incompatibility",
  ]
 
 

--- a/src/rai_toolbox/mushin/_compatibility.py
+++ b/src/rai_toolbox/mushin/_compatibility.py
@@ -28,4 +28,4 @@ def _get_version(ver_str: str) -> Version:
     return Version(major=major, minor=minor, patch=int(patch_str))
 
 
-PL_VERSION: Final = _get_version(pytorch_lightning.__version__)  # type: ignore
+PL_VERSION: Final = _get_version(pytorch_lightning.__version__)

--- a/src/rai_toolbox/mushin/lightning/_pl_main.py
+++ b/src/rai_toolbox/mushin/lightning/_pl_main.py
@@ -10,9 +10,8 @@ import logging
 from typing import Optional
 
 import hydra
+from hydra_zen import zen
 from pytorch_lightning import LightningDataModule, LightningModule, Trainer
-
-from ..hydra import zen
 
 log = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ def task(
         trainer.fit(module, datamodule=datamodule)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(config_path=None, config_name="config", version_base="1.1")
 def main(cfg):
     zen(task)(cfg)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,10 @@ collect_ignore_glob = []
 if not MUSHIN_EXTRAS & _installed:
     collect_ignore_glob.append("test_mushin/*.py")
 
+if "torchvision" not in _installed:
+    collect_ignore_glob.append("tests/test_augmentations/test_fourier.py")
+    collect_ignore_glob.append("tests/test_datasets/*.py")
+
 
 @pytest.fixture()
 def cleandir(tmp_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,8 @@ if not MUSHIN_EXTRAS & _installed:
     collect_ignore_glob.append("test_mushin/*.py")
 
 if "torchvision" not in _installed:
-    collect_ignore_glob.append("tests/test_augmentations/test_fourier.py")
-    collect_ignore_glob.append("tests/test_datasets/*.py")
+    collect_ignore_glob.append("**/test_augmentations/test_fourier.py")
+    collect_ignore_glob.append("**/test_datasets/*.py")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,8 @@ collect_ignore_glob = []
 if not MUSHIN_EXTRAS & _installed:
     collect_ignore_glob.append("test_mushin/*.py")
 
-if "torchviaasion" not in _installed:
+if "torchvision" not in _installed:
+    collect_ignore_glob.append("*test_augmix*")
     collect_ignore_glob.append("*test_augmentations*")
     collect_ignore_glob.append("*test_datasets*")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,9 +24,9 @@ collect_ignore_glob = []
 if not MUSHIN_EXTRAS & _installed:
     collect_ignore_glob.append("test_mushin/*.py")
 
-if "torchvision" not in _installed:
-    collect_ignore_glob.append("**/test_augmentations/test_fourier.py")
-    collect_ignore_glob.append("**/test_datasets/*.py")
+if "torchviaasion" not in _installed:
+    collect_ignore_glob.append("*test_augmentations*")
+    collect_ignore_glob.append("*test_datasets*")
 
 
 @pytest.fixture()

--- a/tests/test_augmix/test_losses.py
+++ b/tests/test_augmix/test_losses.py
@@ -10,7 +10,7 @@ from hypothesis import given, settings
 from hypothesis.extra.numpy import array_shapes, arrays
 from mygrad import no_autodiff
 from mygrad.nnet.activations import softmax
-from torch.testing import assert_allclose
+from torch.testing import assert_close
 
 from rai_toolbox.losses import jensen_shannon_divergence
 
@@ -43,14 +43,14 @@ def test_jsd_symmetry(probs, data: st.DataObject):
     perm_probs = data.draw(st.permutations(probs))
     jsd1 = jensen_shannon_divergence(*probs)
     jsd2 = jensen_shannon_divergence(*perm_probs)
-    assert_allclose(jsd1, jsd2, atol=1e-5, rtol=1e-5)
+    assert_close(jsd1, jsd2, atol=1e-5, rtol=1e-5)
 
 
 @given(probs=st.lists(prob_tensors, min_size=2), weight=st.floats(-10, 10))
 def test_jsd_scaled_by_weight(probs, weight: float):
     jsd1 = jensen_shannon_divergence(*probs)
     jsd2 = jensen_shannon_divergence(*probs, weight=weight)
-    assert_allclose(jsd1 * weight, jsd2, atol=1e-5, rtol=1e-5)
+    assert_close(jsd1 * weight, jsd2, atol=1e-5, rtol=1e-5)
 
 
 @given(probs=st.lists(prob_tensors, min_size=2))
@@ -64,4 +64,4 @@ def test_jsd_max_bounds(num_probs):
     """JSD(P1, P2, ..., Pn)"""
     probs = (t[None] for t in tr.eye(num_probs))
     jsd = float(jensen_shannon_divergence(*probs).item())
-    assert_allclose(jsd, np.log(num_probs))
+    assert_close(jsd, np.log(num_probs), atol=1e-5, rtol=1e-5)

--- a/tests/test_mushin/test_lightning_hydra_ddp.py
+++ b/tests/test_mushin/test_lightning_hydra_ddp.py
@@ -164,6 +164,9 @@ def test_ddp_with_hydra_subprocess_runs_correct_mode(testing, predicting):
 
 
 @pytest.mark.usefixtures("cleandir")
+@pytest.mark.filterwarnings("ignore:The dataloader")
+@pytest.mark.filterwarnings("ignore:It is recommended to use")
+@pytest.mark.filterwarnings("ignore:The number of training batches")
 def test_ddp_with_hydra_with_datamodule():
     module = builds(SimpleLightningModuleNoData)
     datamodule = builds(SimpleDataModule)

--- a/tests/test_mushin/test_workflows.py
+++ b/tests/test_mushin/test_workflows.py
@@ -481,6 +481,8 @@ def test_working_subdirs(
         if k.startswith("hydra") and v is not None
     ]
 
+    # just to keep these from looking like they are unused
+    del hydra_sweep_dir, hydra_sweep_subdir
     wf = GridMetrics()
     wf.run(x=multirun([-1, 0, 1]), y=multirun([-10, 10]), overrides=overrides)
 

--- a/tests/test_optim/test_chained_optim.py
+++ b/tests/test_optim/test_chained_optim.py
@@ -7,7 +7,7 @@ import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import torch as tr
 from hypothesis import given
-from torch.testing import assert_close as assert_allclose  # type: ignore
+from torch.testing import assert_close
 
 from rai_toolbox.optim import (
     ChainedParamTransformingOptimizer,
@@ -106,5 +106,5 @@ def test_chained_optim(x: tr.Tensor, chain: List[Type[PreMul2Grad]]):
     for opt in chain:
         opt._post_step_transform_(None, expected, {})  # type: ignore
 
-    assert_allclose(actual=x, expected=expected)
-    assert_allclose(actual=x.grad, expected=expected.grad)
+    assert_close(actual=x, expected=expected)
+    assert_close(actual=x.grad, expected=expected.grad)

--- a/tests/test_optim/test_grad_transformation.py
+++ b/tests/test_optim/test_grad_transformation.py
@@ -13,7 +13,7 @@ from hypothesis import assume, given, note, settings, strategies as st
 from hypothesis.extra import numpy as hnp
 from torch import Tensor
 from torch.optim import SGD, Adam
-from torch.testing import assert_close as assert_allclose  # type: ignore
+from torch.testing import assert_close
 
 from rai_toolbox import to_batch
 from rai_toolbox._typing import Partial
@@ -489,7 +489,7 @@ def test_grad_transform_optim_param_ndim_equivalence(Optimizer, param):
     assert t1.ndim == t2.ndim + 1
 
     # Ensure optimizer produces identical results
-    assert_allclose(t1, t2[None])
+    assert_close(t1, t2[None])
 
 
 @given(
@@ -513,14 +513,14 @@ def test_l2_normed_grad_for_arbitrary_param_ndim(param, data: st.DataObject):
     optimizer.step()
 
     if param_ndim is None or param_ndim == x.ndim:
-        assert_allclose(tr.norm(x.grad, p=2).item(), 1.0)  # type: ignore
+        assert_close(tr.norm(x.grad, p=2).item(), 1.0)  # type: ignore
         return
 
     if param_ndim < 0:
         param_ndim += x.ndim
 
     if param_ndim == 0:
-        assert_allclose(tr.sign(x_orig), x.grad)
+        assert_close(tr.sign(x_orig), x.grad)
         return
 
     assert x.grad is not None
@@ -531,7 +531,7 @@ def test_l2_normed_grad_for_arbitrary_param_ndim(param, data: st.DataObject):
     # dimensions. Each D-dim vector should have been normalized by the optimizer
     x_grad = x.grad.view(-1, *x.grad.shape[-param_ndim:]).flatten(1)
     norms = tr.norm(x_grad, p=2, dim=1)  # type: ignore
-    assert_allclose(norms, tr.ones_like(norms))
+    assert_close(norms, tr.ones_like(norms))
 
 
 @pytest.mark.parametrize(
@@ -678,8 +678,8 @@ def test_grad_scale_and_bias(
     g2_unnormed = (x2.grad - b2) / s2
     g3_unnormed = (x3.grad - b3) / s3
 
-    assert_allclose(g1_unnormed, g2_unnormed)
-    assert_allclose(g1_unnormed, g3_unnormed)
+    assert_close(g1_unnormed, g2_unnormed)
+    assert_close(g1_unnormed, g3_unnormed)
 
 
 def test_l1q_regression():
@@ -690,7 +690,7 @@ def test_l1q_regression():
     opt = L1qNormedGradientOptim([p], q=0.5, param_ndim=1, lr=1)
     p.backward(g)
     opt.step()
-    assert_allclose(actual=p.grad, expected=tr.tensor([0.0, -0.5, 0.5, 0.0]))
+    assert_close(actual=p.grad, expected=tr.tensor([0.0, -0.5, 0.5, 0.0]))
 
 
 def test_project_is_deprecated():

--- a/tests/test_optim/test_misc.py
+++ b/tests/test_optim/test_misc.py
@@ -8,7 +8,7 @@ import hypothesis.strategies as st
 import pytest
 import torch as tr
 from hypothesis import assume, given, note
-from torch.testing import assert_allclose
+from torch.testing import assert_close
 
 from rai_toolbox.optim import (
     ClampedGradientOptimizer,
@@ -43,7 +43,7 @@ def test_clamped_grad_optim(a: Optional[float], b: Optional[float]):
     x.backward(gradient=grad)
     optim.step()
 
-    assert_allclose(x.grad, tr.clamp(grad, kwargs["clamp_min"], kwargs["clamp_max"]))
+    assert_close(x.grad, tr.clamp(grad, kwargs["clamp_min"], kwargs["clamp_max"]))
 
 
 @given(
@@ -67,7 +67,7 @@ def test_clamped_param_optim(a: Optional[float], b: Optional[float]):
     x.backward(gradient=grad)
     optim.step()
 
-    assert_allclose(
+    assert_close(
         x,
         tr.clamp(tr.arange(-1000.0, 1000.0), kwargs["clamp_min"], kwargs["clamp_max"]),
     )
@@ -87,7 +87,7 @@ def test_top_q_grad(q):
 
     note(f"x.grad: {x.grad}")
     note(f"expected: {expected}")
-    assert_allclose(x.grad, expected)
+    assert_close(x.grad, expected)
 
 
 @pytest.mark.parametrize("generator_device", avail_devices)
@@ -118,5 +118,5 @@ def test_top_q_grad_generator(generator_device):
     seeded_grad1 = get_grad(seed=seed)
     unseeded_grad = get_grad(seed=0)
 
-    assert_allclose(seeded_grad0, seeded_grad1)
+    assert_close(seeded_grad0, seeded_grad1)
     assert tr.any(~tr.isclose(seeded_grad0, unseeded_grad))

--- a/tests/test_optim/test_stateful.py
+++ b/tests/test_optim/test_stateful.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import torch as tr
 from torch.optim import Adam
-from torch.testing import assert_allclose
+from torch.testing import assert_close
 
 from rai_toolbox._typing import Optimizer
 from rai_toolbox.optim import (
@@ -106,17 +106,17 @@ def test_ChainedParamTransformingOptimizer_state_mirrors_InnerOpt():
     optim1.step()
 
     # param_ndim: None
-    assert_allclose(x1.grad, tr.tensor([[0.7071, -0.7071]]), rtol=1e-4, atol=1e-4)
+    assert_close(x1.grad, tr.tensor([[0.7071, -0.7071]]), rtol=1e-4, atol=1e-4)
 
     # param_ndim: 0
-    assert_allclose(x2.grad, tr.tensor([[1.0, -1.0]]), rtol=1e-4, atol=1e-4)
+    assert_close(x2.grad, tr.tensor([[1.0, -1.0]]), rtol=1e-4, atol=1e-4)
 
     # clamp_min: 0.0
-    assert_allclose(x3.grad, tr.tensor([[1.0, 0.0]]), rtol=1e-4, atol=1e-4)
+    assert_close(x3.grad, tr.tensor([[1.0, 0.0]]), rtol=1e-4, atol=1e-4)
 
-    assert_allclose(x1, tr.tensor([[0.8586, -0.8586]]), rtol=1e-4, atol=1e-4)
-    assert_allclose(x2, tr.tensor([[0.9000, -0.9000]]), rtol=1e-4, atol=1e-4)
-    assert_allclose(x3, tr.tensor([[0.8000, -1.0000]]), rtol=1e-4, atol=1e-4)
+    assert_close(x1, tr.tensor([[0.8586, -0.8586]]), rtol=1e-4, atol=1e-4)
+    assert_close(x2, tr.tensor([[0.9000, -0.9000]]), rtol=1e-4, atol=1e-4)
+    assert_close(x3, tr.tensor([[0.8000, -1.0000]]), rtol=1e-4, atol=1e-4)
 
     _check_consistency(optim1)
 

--- a/tests/test_perturbations/test_models.py
+++ b/tests/test_perturbations/test_models.py
@@ -10,7 +10,7 @@ import torch as tr
 from hypothesis import given, settings, strategies as st
 from hypothesis.extra import numpy as hnp
 from omegaconf import ListConfig
-from torch.testing import assert_allclose
+from torch.testing import assert_close
 
 from rai_toolbox.perturbations.init import (
     uniform_like_l1_n_ball_,
@@ -53,7 +53,7 @@ def test_models_additive_pert(perturber, x):
     assert tr.all(params[0].abs() == 0)
 
     xpert = model(x)
-    tr.testing.assert_allclose(xpert, (x + params[0]))
+    tr.testing.assert_close(xpert, (x + params[0]))
 
 
 @pytest.mark.parametrize(
@@ -83,7 +83,7 @@ def test_init_fn_kwargs():
     pert2 = AdditivePerturbation((3,), uniform_like_l1_n_ball_, generator=gen2)
     pert3 = AdditivePerturbation((3,), uniform_like_l1_n_ball_, generator=gen3)
 
-    assert_allclose(pert1.delta, pert2.delta)
+    assert_close(pert1.delta, pert2.delta)
     assert tr.all(pert1.delta != pert3.delta)
 
 

--- a/tests/test_perturbations/test_solvers.py
+++ b/tests/test_perturbations/test_solvers.py
@@ -305,6 +305,7 @@ def test_pert_model_validation(pert_model):
     "optim",
     [SGD, partial(SGD), "instance"],
 )
+@settings(deadline=None)
 @given(x=st.floats(-10.0, 10.0))
 def test_various_forms_of_pert_model(pert_model, optim, x: float):
     # pert_model can be Type[PertModel], Partial[PertModel], or PertModel

--- a/tests/test_utils/test_internal_utils.py
+++ b/tests/test_utils/test_internal_utils.py
@@ -1,6 +1,7 @@
 # Copyright 2023, MASSACHUSETTS INSTITUTE OF TECHNOLOGY
 # Subject to FAR 52.227-11 – Patent Rights – Ownership by the Contractor (May 2014).
 # SPDX-License-Identifier: MIT
+import platform
 from typing import Union
 
 import hypothesis.strategies as st
@@ -32,6 +33,10 @@ def test_type_catches_bad_type(name, target_type, value):
         value_check(name, value=value, type_=target_type)
 
 
+@pytest.mark.skipif(
+    platform.system == "Windows",
+    reason="Weird flakiness involving " "Hypothesis, Python 3.10 and `zoneinfo`",
+)
 @given(
     target_type=st.shared(any_types, key="target_type"),
     value=st.shared(any_types, key="target_type").flatmap(st.from_type),


### PR DESCRIPTION
- Add Python 3.10 to test suite ([Python 3.11 not yet supported by torch](https://github.com/mit-ll-responsible-ai/responsible-ai-toolbox/issues/112))
- Fixes caching in github actions (caching should be based off of pyproject.toml not setup.cfg)
- Remove deprecated use of `torch.testing.assert_allclose` in favor of ``torch.testing.assert_close`
- Fix failing min dependencies tests
- Updates minimum supported torch dependency to 1.10.0
- Removes `torchvision` as required dependency
